### PR TITLE
Addition of multiple algorithm variations (Euclidean & SC Grids) in the module PRO

### DIFF
--- a/L4L_Project/_0_Init_Live4Life.scd
+++ b/L4L_Project/_0_Init_Live4Life.scd
@@ -40,7 +40,7 @@
 
 // Spatial configuration (Nb of outputs and spatial distribution) XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ~numChannelsConfig = "2-Performance"; // Stereo Mix and effects // This line chooses spatial configuration setup // Uncomment according your preferred setup
-~numChannelsConfig = "2-MultiChannelSequencer"; // To get 8 seperated stereo tracks e.g. towards a sequencer - 16 mono effect channels ?
+// ~numChannelsConfig = "2-MultiChannelSequencer"; // To get 8 seperated stereo tracks e.g. towards a sequencer - 16 mono effect channels ?
 // ~numChannelsConfig = "4"; // Clockwise Quad
 // ~numChannelsConfig = "5-Clock"; // Clockwise from Centre = 0
 // ~numChannelsConfig = "5-Centre"; // Clockwise from Links (except Centre = 3) - XXXXXXXXX
@@ -94,7 +94,7 @@ For large-scale concert presentation, the authors advise auditioning values of k
 
 // 3.do { Server.killAll }; // Wait RESULT = 1 before executing the following steps
 fork { Server.killAll; /*0.1.wait;*/ s.waitForBoot({ /*0.1.wait;*/ 2.do { 0.1.wait; Server.killAll };
-	0.1.wait; "".postln; ("Spatial Config ->" + ~numChannelsConfig).postln; ("Preset Filename ->" + ~presetsFileName).postln; if (~presetsFileName2.notNil, {("Preset Filename 2 ->" + ~presetsFileName2).postln}); "".postln;
+	0.1.wait; "".postln; ("Spatial Config ->" + ~numChannelsConfig).postln; ("Preset Filename ->" + ~presetsFileName).postln; if (~presetsFileName2.notNil, {("Preset Filename 2 ->" + ~presetsFileName2).postln}); "".postln; // Document.current.selectRange(103,118);
 }); }; // Server.allRunningServers;
 )
 
@@ -138,7 +138,7 @@ fork { Server.killAll; /*0.1.wait;*/ s.waitForBoot({ /*0.1.wait;*/ 2.do { 0.1.wa
 
 
 // INIT GUI (Server 1 until track 2 and Server 2 from track 3) XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-~nbOfControlBus = 6; ~serverTrackSwitch = 2; "_2_Init_GUI_221.scd".loadRelative;
+~nbOfControlBus = 6; ~serverTrackSwitch = 2; "_2_Init_GUI_222.scd".loadRelative;
 
 // Lemur Connection
 ~lemurConnected1 = 1; ~lemurAdress1 = NetAddr( "169.254.174.68", 8000);
@@ -148,7 +148,7 @@ fork { Server.killAll; /*0.1.wait;*/ s.waitForBoot({ /*0.1.wait;*/ 2.do { 0.1.wa
 
 
 // INIT PATTERN XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-~updateTime = 0.2 /*0.1*/; "_3_Init_Pattern_181.scd".loadRelative;
+~updateTime = 0.2 /*0.1*/; "_3_Init_Pattern_182.scd".loadRelative;
 
 if ( ~serverFX == 0, { ~initFXSynthDefs.(\server1, 0) }, { ~initFXSynthDefs.(\serverFX1, 0) } );
 if ( ~serverFX == 0, { ~initFXSynthDefs.(\server2, 1) }, { ~initFXSynthDefs.(\serverFX2, 1) } );

--- a/L4L_Project/_1_Init_BuffersSynths_130.scd
+++ b/L4L_Project/_1_Init_BuffersSynths_130.scd
@@ -14685,7 +14685,7 @@ t.quit;
 		{
 			~trajectoryBuffersX = Env( { 10.0.rand2 }!2, 0.5!1 );
 			~trajectoryBuffersY = Env( { 10.0.rand2 }!2, 0.5!1 );
-			~testWindow = Window.new; ~testWindow.front;
+			~testWindow = Window.new; ~testWindow.visible = 1 /*front*/; // visible au lieu de front afin que l'IDE soit toujours en avant plan malgré la construction d'une GUI
 			~trajectoryBuffersA = WFSPathGUI.new(~testWindow);
 			~trajectoryBuffersA.object = WFSPath2( [ ~trajectoryBuffersX.levels, ~trajectoryBuffersY.levels ].flop.collect(_.asPoint), ~trajectoryBuffersX.times );
 			~trajectoryBuffersTest = ~trajectoryBuffersA.object.asBuffer(currentEnvironment[server]);

--- a/L4L_Project/_2_Init_GUI_222.scd
+++ b/L4L_Project/_2_Init_GUI_222.scd
@@ -1376,12 +1376,19 @@ if (~multiTemp.isNil, {"You need to copy data !!!".postln}, {
 
 		// Pour la rythmique euclidienne
 		~proBjorSpec[track][seq] = ControlSpec(0, ~dur[track][seq].size, \lin, 1);
-		~proBjorView.step_(1/dur);
-		~proBjor2View.step_(1/dur);
+		if (~proPatSel[~tracksValue][~seqsValue] > 18, {
+			~proBjorView.step_(0.001); ~proBjor2View.step_(0.001); ~proBjor3View.step_(0.001); ~proBjor4View.step_(0.001);
+		},{
+			~proBjorView.step_(1/dur); ~proBjor2View.step_(1/dur); ~proBjor3View.step_(dur); ~proBjor4View.step_(dur);
+		});
 		~proBjorView.doAction;
 		~proBjor2View.doAction;
+		~proBjor3View.doAction;
+		~proBjor4View.doAction;
 		~proBjor[track][seq] = ~dur[track][seq].size;
 		~proBjor2[track][seq] = ~dur[track][seq].size;
+		~proBjor3[track][seq] = ~dur[track][seq].size;
+		~proBjor4[track][seq] = ~dur[track][seq].size;
 	};
 
 	// Changement des menus mis dans le Copy & Paste mais à ne pas mettre dans les presets XXXXXXX
@@ -1442,6 +1449,10 @@ if (~multiTemp.isNil, {"You need to copy data !!!".postln}, {
 		~proSeqMode.valueAction_(1);
 		~proRangeMode.valueAction_(0);
 		~proBjorView.valueAction_(1);
+		~proBjor2View.valueAction_(1);
+		~proBjor3View.valueAction_(1);
+		~proBjor4View.valueAction_(1);
+		~proWeightView.valueAction_(1);
 		~proDirView.valueAction_(0);
 		~proPatView.valueAction_(0);
 		~proPatSelView.valueAction_(13);
@@ -1450,10 +1461,14 @@ if (~multiTemp.isNil, {"You need to copy data !!!".postln}, {
 		~proBjorSpec[track][seq] = ControlSpec(0, seqDur, \lin, 1);
 		~proBjorView.step_(1/~dur[~tracksValue][~seqsValue].size);
 		~proBjor2View.step_(1/~dur[~tracksValue][~seqsValue].size);
+		// ~proBjor4View.step_(1/~dur[~tracksValue][~seqsValue].size);
 		~proBjorView.doAction;
 		~proBjor2View.doAction;
+		// ~proBjor4View.doAction;
 		~proBjor[track][seq] = seqDur;
 		~proBjor2[track][seq] = seqDur;
+		~proBjor3[track][seq] = seqDur;
+		~proBjor4[track][seq] = seqDur;
 	};
 
 
@@ -3103,8 +3118,10 @@ m = PdefAllGui(8, bounds: Rect(30, 900, 60, 60));*/
 	~quantView.valueAction_(~quantSpec.unmap(~quant[tr]));
 	~rtmMulView.valueAction_(~rtmMulSpec[tr][seq].unmap(~rtmMul[tr][seq]));
 	~proPatView.valueAction_(~proPat[tr][seq]);
-	~proBjorView.valueAction_(~proBjorSpec[tr][seq].unmap(~proBjor[tr][seq]));
-	~proBjor2View.valueAction_(~proBjorSpec[tr][seq].unmap(~proBjor2[tr][seq]));
+	// ~proBjorView.valueAction_(~proBjorSpec[tr][seq].unmap(~proBjor[tr][seq])); // Old avant SC Grids
+	// ~proBjor2View.valueAction_(~proBjorSpec[tr][seq].unmap(~proBjor2[tr][seq])); // Old avant SC Grids
+	~proBjorView.valueAction_(~proBjorGridsX[tr][seq]);
+	~proBjor2View.valueAction_(~proBjorGridsY[tr][seq]);
 	~proSelectView.valueAction_(~proSelect[tr][seq]);
 	~proMulView.valueAction_(~proMulSpec.unmap(~proMul[tr][seq]));
 	~ratMulView.valueAction_(~ratMulSpec.unmap(~ratMul[tr][seq])); ~rat2MulView.valueAction_(~ratMulSpec.unmap(~rat2Mul[tr][seq]));
@@ -3131,8 +3148,10 @@ m = PdefAllGui(8, bounds: Rect(30, 900, 60, 60));*/
 	// ~quantViewG[tr].value_(~quantSpec.unmap(~quant[tr])).string = ("Q:%-%s").format(~quant[tr], (~quant[tr] / ~toTempo).round(0.01)); // pas necessaire car pas une info d'un preset
 	~rtmMulViewG[tr].value_(~rtmMulSpec[tr][seq].unmap(~rtmMul[tr][seq])).string = "Rtm : %".format(~rtmMul[tr][seq].round(0.001));
 	~proPatViewG[tr].value_(~proPat[tr][seq]);
-	~proBjorViewG[tr].value_(~proBjorSpec[tr][seq].unmap(~proBjor[tr][seq])).string = "Hit : %".format(~proBjor[tr][seq].asInteger);
-	~proBjor2ViewG[tr].value_(~proBjorSpec[tr][seq].unmap(~proBjor2[tr][seq])).string = "Off : %".format(~proBjor2[tr][seq].asInteger);
+	// ~proBjorViewG[tr].value_(~proBjorSpec[tr][seq].unmap(~proBjor[tr][seq])).string = "Hit : %".format(~proBjor[tr][seq].asInteger); // Old avant SC Grids
+	// ~proBjor2ViewG[tr].value_(~proBjorSpec[tr][seq].unmap(~proBjor2[tr][seq])).string = "Off : %".format(~proBjor2[tr][seq].asInteger); // Old avant SC Grids
+	~proBjorViewG[tr].value_(~proBjorGridsX[tr][seq]).string = "H: %-%".format(~proBjor[tr][seq], ~proBjorGridsX[tr][seq]);
+	~proBjor2ViewG[tr].value_(~proBjorGridsY[tr][seq]).string = "O: %-%".format(~proBjor2[tr][seq], ~proBjorGridsY[tr][seq]);
 	~proSelectViewG[tr].value_(~proSelect[tr][seq]);
 	~proMulViewG[tr].value_(~proMulSpec.unmap(~proMul[tr][seq])).string = "Pro : %".format(~proMul[tr][seq].round(0.01));
 	~ratMulViewG[tr].value_(~ratMulSpec.unmap(~ratMul[tr][seq])).string = "Rat : %".format(~ratMul[tr][seq].round(0.01)); // ~rat2MulView.valueAction_(~ratMulSpec.unmap(~rat2Mul[tr][seq]));
@@ -3498,9 +3517,9 @@ Ndef(\sound).play
 
 	// ~dbSpec = \db.asSpec
 	// 12.dbamp
-	~dbSpec =  ControlSpec(0.ampdb, 1.9952/*3.98107*/.ampdb, \db, units: " dB");
-	~dbSpec2 =  ControlSpec(0.ampdb, 1/*3.98107*/.ampdb, \db, units: " dB");
-	~dbSpec2b =  ControlSpec(0.ampdb, 1.9952/*3.98107*/.ampdb, \db, units: " dB"); // Pour booster les pistes trames
+	~dbSpec = ControlSpec(0.ampdb, 1.9952/*3.98107*/.ampdb, \db, units: " dB");
+	~dbSpec2 = ControlSpec(0.ampdb, 1/*3.98107*/.ampdb, \db, units: " dB");
+	~dbSpec2b = ControlSpec(0.ampdb, 1.9952/*3.98107*/.ampdb, \db, units: " dB"); // Pour booster les pistes trames
 	// ~globalBus.set(~dbSpec.unmap(0));
 	// ~volumeBus[0];
 
@@ -10782,7 +10801,7 @@ pair for phase modulation, which sounds similar to FM
 	case
 	{ [\dur].includes(data) }
 	{
-		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Rt", "Rt_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I"])
+		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Rt", "Rt_I", "Pro", "Pro_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I"])
 		.valueAction_(0);
 	}
 	{ [\syn, \env, /*\buf, \off,*/ \fxL, \fxR /*, \del*/].includes(data) }
@@ -10800,12 +10819,12 @@ pair for phase modulation, which sounds similar to FM
 	}
 	{ [\leg, \pan, \buf, \off, \del].includes(data) }
 	{
-		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Leh_1", "Leh1I", "Leh_2", "Leh2I", "Rt", "Rt_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I"])
+		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Leh_1", "Leh1I", "Leh_2", "Leh2I", "Rt", "Rt_I", "Pro", "Pro_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I"])
 		.valueAction_(4); // Initialisation à Pwhite
 	}
 	{ [\amp, \rat, \str, \cen, \rat2, \str2, \cen2].includes(data) }
 	{
-		envir[patSelView].items_([["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Leh_1", "Leh1I", "Leh_2", "Leh2I", "Rt", "Rt_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I"], ~controlBusNames/*, ~controlBusNames01, ~controlBusNames0R*/].flatten)
+		envir[patSelView].items_([["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Leh_1", "Leh1I", "Leh_2", "Leh2I", "Rt", "Rt_I", "Pro", "Pro_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I"], ~controlBusNames/*, ~controlBusNames01, ~controlBusNames0R*/].flatten)
 		.valueAction_(4); // Initialisation à Pwhite
 	}
 	/*{ \leg == data } // DurRe ?????????
@@ -10820,17 +10839,17 @@ pair for phase modulation, which sounds similar to FM
 	}*/
 	{ \pro == data }
 	{
-		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", /*"Leh_1", "Leh_2",*/ "Eucli"])
+		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", /*"Leh_1", "Leh_2",*/ "Eucli", "EuWe", "Eu2X", "Eu2R", "Eu2S", "Eu2W", "Grids", "Gri_D", "Gri_P", "Gri_R"])
 		.valueAction_(13);
 	}
 	{ \outL == data }
 	{
-		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Leh_1", "Leh1I", "Leh_2", "Leh2I", "Rt", "Rt_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I", "Sq +1", "Sq -1", "Sq +2", "Sq -2", "Sq Mir"])
+		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Leh_1", "Leh1I", "Leh_2", "Leh2I", "Rt", "Rt_I", "Pro", "Pro_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I", "Sq +1", "Sq -1", "Sq +2", "Sq -2", "Sq Mir"])
 		.valueAction_(47); // ~controlBus0 -> mais déclaré dans le pattern
 	}
 	{ \outR == data }
 	{
-		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Leh_1", "Leh1I", "Leh_2", "Leh2I", "Rt", "Rt_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I", "L +1", "L -1", "L+1/4", "L-1/4", "L Opp", "Other"])
+		envir[patSelView].items_(["Rand", "Xrand", "Shuff", "Walk", "White", "Expra", "Lpran", "Meanr", "Hpran", "Gauss", "Brown", "Gbrow", "Cauch", "Leh_1", "Leh1I", "Leh_2", "Leh2I", "Rt", "Rt_I", "Pro", "Pro_I", "Du", "Du_I", "Amp", "Amp_I", "Rat", "Rat_I", "Str", "Str_I", "Cen", "Cen_I", "Ra2", "Ra2_I", "St2", "St2_I", "Ce2", "Ce2_I", "Buf", "Buf_I", "Po", "Po_I", "Pan", "Pan_I", "Del", "Del_I", "L", "L_I", "R", "R_I", "L +1", "L -1", "L+1/4", "L-1/4", "L Opp", "Other"])
 		.valueAction_(47);
 	};
 
@@ -11016,8 +11035,16 @@ readView, readBackgroundColorView, posView
 
 	~posPro = 0 ! ~nbOfSeqs ! ~nbOfTracksX2; // Déclaration variables pour le Pattern
 	~proBjorSpec = 0 ! ~nbOfSeqs ! ~nbOfTracksX2; // pour Bjorklund
-	~proBjor = 0 ! ~nbOfSeqs ! ~nbOfTracksX2; // pour Bjorklund
-	~proBjor2 = 0 ! ~nbOfSeqs ! ~nbOfTracksX2; // pour Bjorklund
+	~proBjor = /*0*/ ~dur[~tracksValue][~seqsValue].size ! ~nbOfSeqs ! ~nbOfTracksX2; // pour Bjorklund
+	~proBjorGridsX = 1 ! ~nbOfSeqs ! ~nbOfTracksX2; // pour SC Grids X - Bjorklund en raw
+	~proBjor2 = /*0*/ ~dur[~tracksValue][~seqsValue].size ! ~nbOfSeqs ! ~nbOfTracksX2; // pour Bjorklund
+	~proBjorGridsY = 1 ! ~nbOfSeqs ! ~nbOfTracksX2; // pour SC Grids Y - Bjorklund en raw
+	~proWeight = 1 ! ~nbOfSeqs ! ~nbOfTracksX2;
+	~proDrumType = \kick ! ~nbOfSeqs ! ~nbOfTracksX2;
+	~proBjor3 = /*0*/ ~dur[~tracksValue][~seqsValue].size ! ~nbOfSeqs ! ~nbOfTracksX2;
+	~proBjor4 = /*0*/ ~dur[~tracksValue][~seqsValue].size ! ~nbOfSeqs ! ~nbOfTracksX2;
+	~proGridsBias = 1 ! ~nbOfSeqs ! ~nbOfTracksX2;
+	~proGridsBias2 = 1 ! ~nbOfSeqs ! ~nbOfTracksX2;
 
 	~proT = 0 ! ~nbOfTracksX2; // Changement du nom de ~proTemp à ~proT, car ~proTemp est déjà utilisé pour faire le copier / coller du module PRO
 	~proSelect = 0 ! ~nbOfSeqs ! ~nbOfTracksX2;
@@ -11041,9 +11068,27 @@ readView, readBackgroundColorView, posView
 		\proReadView, Color.grey(0.6) /*Color.magenta*/ /*~rtmCompColor.alpha_(0)*/, \proPosView
 	);
 
+
+	~drawSCGrids = { // inclure la fonction ~drawSCGrids dans ~proMulView - mais pas fait pour éviter de rajouter une fonction if dans ~proMulView
+		if (~visuelSlider == 0, {
+			~getSCGridsLevels = ~pro[~tracksValue][~seqsValue].size.collect { |i|
+				var level = ScGrids.calculateLevel(\kick, i, ~proBjorGridsX[~tracksValue][~seqsValue], ~proBjorGridsY[~tracksValue][~seqsValue], ~proGridsBias[~tracksValue][~seqsValue] );
+				if  ( level >= (1-~gridsDens[~tracksValue][~seqsValue]), {level}, {0});
+			};
+			{~proView.valueAction_(~getSCGridsLevels)}.defer;
+		});
+	};
+
+
 	~proBjorView = SmoothSlider(~proComp, ~miniSlider1Pos5)
-	.action_({ |view| ~proBjor[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue][~seqsValue].map(view.value).asInteger;
-		view.string = "Hit : %".format(~proBjor[~tracksValue][~seqsValue]);
+	.action_({ |view|
+		~proBjor[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue][~seqsValue].map(view.value).asInteger;
+		~proBjorGridsX[~tracksValue][~seqsValue] = view.value.round(0.001);
+		if (~proPatSel[~tracksValue][~seqsValue] > 18 /*and: {~proPat[~tracksValue][~seqsValue] == 1}*/, {
+			view.string = "GX : %".format(~proBjorGridsX[~tracksValue][~seqsValue]); ~drawSCGrids.();
+		}, {
+			view.string = "Hit : %".format(~proBjor[~tracksValue][~seqsValue]);
+		});
 	}) // Action redéfinie dans le Global
 	.font_(Font("Verdana", 9))
 	.background_(Color.magenta)
@@ -11052,12 +11097,18 @@ readView, readBackgroundColorView, posView
 	.border_(~border)
 	.borderColor_(~borderColor)
 	.step_(1/~pro[~tracksValue][~seqsValue].size)
-	.valueAction_( 1 /*~proBjorSpec[~tracksValue][~seqsValue].unmap(1)*/)
+	.value_( 1 /*~proBjorSpec[~tracksValue][~seqsValue].unmap(1)*/)
 	.doAction;
 
 	~proBjor2View = SmoothSlider(~proComp, ~miniSlider2Pos5)
-	.action_({ |view| ~proBjor2[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue][~seqsValue].map(view.value).asInteger;
-		view.string = "Off : %".format(~proBjor2[~tracksValue][~seqsValue]);
+	.action_({ |view|
+		~proBjor2[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue][~seqsValue].map(view.value).asInteger;
+		~proBjorGridsY[~tracksValue][~seqsValue] = view.value.round(0.001);
+		if (~proPatSel[~tracksValue][~seqsValue] > 18 /*and: {~proPat[~tracksValue][~seqsValue] == 1}*/, {
+			view.string = "GY : %".format(~proBjorGridsY[~tracksValue][~seqsValue]); ~drawSCGrids.();
+		}, {
+			view.string = "Off : %".format(~proBjor2[~tracksValue][~seqsValue]);
+		});
 	}) // Action redéfinie dans le Global
 	.font_(Font("Verdana", 9))
 	.background_(Color.magenta)
@@ -11066,8 +11117,103 @@ readView, readBackgroundColorView, posView
 	.border_(~border)
 	.borderColor_(~borderColor)
 	.step_(1/~pro[~tracksValue][~seqsValue].size)
-	.valueAction_( 1 /*~proBjorSpec[~tracksValue][~seqsValue].unmap(1)*/)
+	.value_( 1 /*~proBjorSpec[~tracksValue][~seqsValue].unmap(1)*/)
 	.doAction;
+
+	~proBjor3View = SmoothSlider(~proComp, Rect(274, 156, 60, 18))
+	.action_({ |view|
+		~proBjor3[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue][~seqsValue].map(view.value).asInteger;
+		~proGridsBias[~tracksValue][~seqsValue] = view.value.round(0.001);
+		if (~proPatSel[~tracksValue][~seqsValue] > 18 /*and: {~proPat[~tracksValue][~seqsValue] == 1}*/, {
+			// view.string = "Bi : %".format(~proGridsBias[~tracksValue][~seqsValue]);
+			if (~proPatSel[~tracksValue][~seqsValue] > 21, { view.string = "GX2 : %".format(~proGridsBias[~tracksValue][~seqsValue]) }, { view.string = "Bi : %".format(~proGridsBias[~tracksValue][~seqsValue]); ~drawSCGrids.(); });
+		}, {
+			view.string = "H2 : %".format(~proBjor3[~tracksValue][~seqsValue]);
+		});
+	})
+	.font_(Font("Verdana", 9))
+	.background_(Color.magenta)
+	.hilightColor_(~sliderHilightColor)
+	.stringColor_(Color.white)
+	.border_(~border)
+	.borderColor_(~borderColor)
+	.step_(1/~pro[~tracksValue][~seqsValue].size)
+	.value_( 1 /*~proBjorSpec[~tracksValue][~seqsValue].unmap(1)*/)
+	.doAction;
+
+	~proBjor4View = SmoothSlider(~proComp, Rect(274, 174, 60, 18))
+	.action_({ |view|
+		~proBjor4[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue][~seqsValue].map(view.value).asInteger;
+		~proGridsBias2[~tracksValue][~seqsValue] = view.value.round(0.001);
+
+		case
+		{ ~proPatSel[~tracksValue][~seqsValue] < 20 } { view.string = "O2 : %".format(~proBjor4[~tracksValue][~seqsValue]) }
+		{ ~proPatSel[~tracksValue][~seqsValue] < 22 } { view.string = "Px : %".format(~proGridsBias2[~tracksValue][~seqsValue]) }
+		{ ~proPatSel[~tracksValue][~seqsValue] == 22 } { view.string = "GY2 : %".format(~proGridsBias2[~tracksValue][~seqsValue]) }
+
+	})
+	.font_(Font("Verdana", 9))
+	.background_(Color.magenta)
+	.hilightColor_(~sliderHilightColor)
+	.stringColor_(Color.white)
+	.border_(~border)
+	.borderColor_(~borderColor)
+	.step_(1/~pro[~tracksValue][~seqsValue].size)
+	.value_( 1 /*~proBjorSpec[~tracksValue][~seqsValue].unmap(1)*/)
+	.doAction;
+
+	~proWeightView = SmoothSlider(~proComp, Rect(212, 156, 60, 18))
+	.action_({ |view|
+		~proWeight[~tracksValue][~seqsValue] = view.value;
+		view.string = "We : %".format(~proWeight[~tracksValue][~seqsValue])
+	})
+	.font_(Font("Verdana", 9))
+	.background_(Color.magenta)
+	.hilightColor_(~sliderHilightColor)
+	.stringColor_(Color.white)
+	.border_(~border)
+	.borderColor_(~borderColor)
+	.step_(0.001)
+	.value_( 1 /*~proBjorSpec[~tracksValue][~seqsValue].unmap(1)*/)
+	.doAction;
+
+	~proDrumTypeView = PopUpMenu.new(~proComp, Rect(212, 174, 60, 18))
+	.allowsReselection_(true)
+	.background_(~popUpMenuBackgroundColor)
+	.stringColor_(~popUpMenuStringColor)
+	.font_(Font("Verdana",9))
+	.action_({|menu| ~proDrumType[~tracksValue][~seqsValue] = menu.item; })
+	.items_([\kick, \hihat, \snare]);
+
+	// Redéfinition de l'action pour prendre en compte SC Grids et variations d'Euclid
+	~proPatSelView.action_({|menu| var dur = 1/~pro[~tracksValue][~seqsValue].size;
+		~proPatSel[~tracksValue][~seqsValue] = menu.value;
+		~proBlock[~tracksValue] = 1;
+
+		case
+		{ ~proPatSel[~tracksValue][~seqsValue] < 14 } { ~proBjor3View.visible_(0); ~proBjor4View.visible_(0); ~proWeightView.visible_(0); ~proDrumTypeView.visible_(0); }
+		{ ~proPatSel[~tracksValue][~seqsValue] == 14 } { ~proBjor3View.visible_(1); ~proBjor4View.visible_(0); ~proWeightView.visible_(1); ~proDrumTypeView.visible_(0); }
+		{ ~proPatSel[~tracksValue][~seqsValue] == 15 } { ~proBjor3View.visible_(1); ~proBjor4View.visible_(1); ~proWeightView.visible_(0); ~proDrumTypeView.visible_(0); }
+		{ ~proPatSel[~tracksValue][~seqsValue] == 16 } { ~proBjor3View.visible_(1); ~proBjor4View.visible_(0); ~proWeightView.visible_(0); ~proDrumTypeView.visible_(0); }
+		{ ~proPatSel[~tracksValue][~seqsValue] == 17 } { ~proBjor3View.visible_(1); ~proBjor4View.visible_(0); ~proWeightView.visible_(0); ~proDrumTypeView.visible_(0); }
+		{ ~proPatSel[~tracksValue][~seqsValue] == 18 } { ~proBjor3View.visible_(1); ~proBjor4View.visible_(1); ~proWeightView.visible_(1); ~proDrumTypeView.visible_(0); }
+		{ ~proPatSel[~tracksValue][~seqsValue] == 19 } { ~proBjor3View.visible_(1); ~proBjor4View.visible_(0); ~proWeightView.visible_(1); ~proDrumTypeView.visible_(1); }
+		{ ~proPatSel[~tracksValue][~seqsValue] > 19 } { ~proBjor3View.visible_(1); ~proBjor4View.visible_(1); ~proWeightView.visible_(1); ~proDrumTypeView.visible_(1); };
+		// { ~proPatSel[~tracksValue][~seqsValue] == 21 } { ~proBjor3View.visible_(1); ~proBjor4View.visible_(1); ~proWeightView.visible_(1); ~proDrumTypeView.visible_(1); }
+
+		if (~proPatSel[~tracksValue][~seqsValue] > 18, {
+			~proBjorView.step_(0.001); ~proBjor2View.step_(0.001); ~proBjor3View.step_(0.001); ~proBjor4View.step_(0.001);
+		},{
+			~proBjorView.step_(dur); ~proBjor2View.step_(dur); ~proBjor3View.step_(dur); ~proBjor4View.step_(dur);
+		});
+
+		~proBjorView.value_(~proBjorGridsX[~tracksValue][~seqsValue]).doAction;
+		~proBjor2View.value_(~proBjorGridsY[~tracksValue][~seqsValue]).doAction;
+		~proBjor3View.value_(~proGridsBias[~tracksValue][~seqsValue]).doAction;
+		~proBjor4View.value_(~proGridsBias2[~tracksValue][~seqsValue]).doAction;
+
+		if (~patFlag == 1, {~seqs.do {|sequence| ~proPatSel[~tracksValue][sequence] = menu.value }});
+	});
 
 	// Action mis plus bas car necessité de le déclarer après ~proSelectViewG car action sur le Global
 	~proSelectView = RoundButton(~proComp, Rect(337, 2, 60/*30*/, 16))
@@ -14831,7 +14977,7 @@ data.postln;*/
 
 		var presetIndex;
 		var serv;
-		// Utilisation seulement du ~dur car la nb d'éléments dans toutes les séquences est le même
+		// Utilisation seulement du ~dur car le nb d'éléments dans toutes les séquences est le même
 		var rtmSeqSize = ~dur[~tracksValue][~seqsValue].size;
 		var rtmThumbSize = max(333 / rtmSeqSize, ~readViewThumbSize);
 		var rtmSeqStep = 1 / rtmSeqSize;
@@ -15130,10 +15276,10 @@ data.postln;*/
 		// ~offMulView.value_(~offMulSpec.unmap(~offMul[~tracksValue][~seqsValue])).doAction;
 		~strMulView.value_(~strMulSpec.unmap(~strMul[~tracksValue][~seqsValue])).doAction;
 		~cenMulView.value_(~cenMulSpec.unmap(~cenMul[~tracksValue][~seqsValue])).doAction;
-		~bufMulView.value_(~bufMulSpec.unmap(~bufMul[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/)).doAction;
+		~bufMulView.value_(~bufMulSpec.unmap(~bufMul[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue])).doAction; // Changement GUI 221
 		// ~bufMul[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.postln; ~bufMul[~tracksValue][~seqsValue].postln;
 		// 2 mises à jour successives : [~seqSeq[~tracksValue]] donne une première bonne valeur, alors [~seqsValue] donne une première mauvaise valeur qui est bien updaté par la suite
-		~offMulView.value_(~offMulSpec.unmap(~offMul[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/)).doAction;
+		~offMulView.value_(~offMulSpec.unmap(~offMul[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue])).doAction; // Changement GUI 221
 
 		/*if (~twister.notNil, {
 		~ratValues[~tracksValue].value_(~ratMulSpec.unmap(~ratMul[~tracksValue][~seqsValue]/*[~seqSeq[~tracksValue]]*/));
@@ -15191,9 +15337,9 @@ data.postln;*/
 		~fxRDirView.valueAction_(~fxRDir[~tracksValue][~seqsValue]);
 
 		~rtmPatView.valueAction_(~rtmPat[~tracksValue][~seqsValue]);
-		~proPatView.value_(~proPat[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/).doAction; // A mettre sur tout ??? pour action sur le global
+		~proPatView.value_(~proPat[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue]).doAction; // A mettre sur tout ??? pour action sur le global // Changement GUI 221
 		~synPatView.valueAction_(~synPat[~tracksValue][~seqsValue]);
-		~spaPatView.value_(~spaPat[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/).doAction; // A mettre sur tout ??? pour action sur le global
+		~spaPatView.value_(~spaPat[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue]).doAction; // A mettre sur tout ??? pour action sur le global // Changement GUI 221
 		~legPatView.valueAction_(~legPat[~tracksValue][~seqsValue]);
 		~envPatView.valueAction_(~envPat[~tracksValue][~seqsValue]);
 		~bufPatView.valueAction_(~bufPat[~tracksValue][~seqsValue]);
@@ -15218,9 +15364,9 @@ data.postln;*/
 		~fxRPatView.valueAction_(~fxRPat[~tracksValue][~seqsValue]);
 
 		~rtmPatSelView.valueAction_(~rtmPatSel[~tracksValue][~seqsValue]);
-		~proPatSelView.valueAction_(~proPatSel[~tracksValue][~seqsValue]);
+		// ~proPatSelView.valueAction_(~proPatSel[~tracksValue][~seqsValue]); // remis plus bas car agit sur le step et l'apparition des données
 		~synPatSelView.valueAction_(~synPatSel[~tracksValue][~seqsValue]);
-		~spaPatSelView.valueAction_(~spaPatSel[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/); //
+		~spaPatSelView.valueAction_(~spaPatSel[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue]); // Changement GUI 221
 		~legPatSelView.valueAction_(~legPatSel[~tracksValue][~seqsValue]);
 		~envPatSelView.valueAction_(~envPatSel[~tracksValue][~seqsValue]);
 		~bufPatSelView.valueAction_(~bufPatSel[~tracksValue][~seqsValue]);
@@ -15241,11 +15387,22 @@ data.postln;*/
 		~rtmTypeView.valueAction_(~rtmType[~tracksValue][~seqsValue]);
 		~rtmTypeView2.valueAction_(~sequenceType[~tracksValue][~seqsValue]);
 		// if (~rtmTypeView2.value != ~sequenceType[~tracksValue][~seqsValue], {~rtmTypeView2.valueAction_(~sequenceType[~tracksValue][~seqsValue]) });
+
 		// ~proBjorSpec[~tracksValue][~seqsValue] = rtmSeqSpec; // Pas nécessaire car les SeqSpec sont initiés auparavant
-		~proBjorView.step_(rtmSeqStep).value_(~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.unmap(~proBjor[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/)).doAction; // doAction pour mise à jour du Spec & action sur le global
-		~proBjor2View.step_(rtmSeqStep).value_(~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.unmap(~proBjor2[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/)).doAction; // doAction pour mise à jour du Spec & action sur le global
+		/*~proBjorView.step_(rtmSeqStep).valueAction_(~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.unmap(~proBjor[~tracksValue][~seqSeq[~tracksValue]] /*[~seqsValue]*/)).doAction; // doAction pour mise à jour du Spec & action sur le global
+		~proBjor2View.step_(rtmSeqStep).valueAction_(~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.unmap(~proBjor2[~tracksValue][~seqSeq[~tracksValue]] /*[~seqsValue]*/)).doAction; // doAction pour mise à jour du Spec & action sur le global*/
 		// ~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]].postln; ~proBjorSpec[~tracksValue][~seqsValue].postln;
-		~proSelectView.value_(~proSelect[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/).doAction; // doAction -> necessaire pour action sur le global
+		// Auparavant [~seqSeq[~tracksValue]] à la place de [~seqsValue] - To check ???
+		~proBjorView/*.step_(rtmSeqStep)*/.value_(/*~proBjorSpec[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue].unmap(~proBjor[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue])*/ ~proBjorGridsX[~tracksValue][~seqsValue]).doAction; // doAction pour mise à jour du Spec & action sur le global // Changement GUI 221
+		~proBjor2View/*.step_(rtmSeqStep)*/.value_(/*~proBjorSpec[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue].unmap(~proBjor2[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue])*/ ~proBjorGridsY[~tracksValue][~seqsValue]).doAction; // doAction pour mise à jour du Spec & action sur le global // Changement GUI 221
+		~proSelectView.value_(~proSelect[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue]).doAction; // doAction -> necessaire pour action sur le global // Changement GUI 221
+
+		~proBjor3View.value_(~proGridsBias[~tracksValue][~seqsValue]).doAction;
+		~proBjor4View.value_(~proGridsBias2[~tracksValue][~seqsValue]).doAction;
+		~proWeightView.valueAction_(~proWeight[~tracksValue][~seqsValue]);
+		~proDrumTypeView.valueAction_(~proDrumType[~tracksValue][~seqsValue]);
+
+		~proPatSelView.valueAction_(~proPatSel[~tracksValue][~seqsValue]); // était plus haut mais doit agir sur le step et l'apparition des données
 
 		~synTypeView.valueAction_(~synType[~tracksValue][~seqsValue]);
 		~offRateSecondBufView.valueAction_(~offRateSecondBufSpec.unmap(~offRateSecondBuf[~tracksValue][~seqsValue]));
@@ -15832,6 +15989,14 @@ if (File.fileSize(~presetspath) <= 21, {
 			\seqType -> ~sequenceType[~tracksValue][~seqsValue],
 			\proBjor -> ~proBjor[~tracksValue][~seqsValue],
 			\proBjor2 -> ~proBjor2[~tracksValue][~seqsValue],
+
+			\proBjor3 -> ~proBjor3[~tracksValue][~seqsValue],
+			\proBjor4 -> ~proBjor4[~tracksValue][~seqsValue],
+			\proGridsBias -> ~proGridsBias[~tracksValue][~seqsValue],
+			\proGridsBias2 -> ~proGridsBias2[~tracksValue][~seqsValue],
+			\proWeight -> ~proWeight[~tracksValue][~seqsValue],
+			\proDrumType -> ~proDrumType[~tracksValue][~seqsValue],
+
 			\proSelect -> ~proSelect[~tracksValue][~seqsValue],
 			\synType -> ~synType[~tracksValue][~seqsValue],
 			\offRateSecondBuf -> ~offRateSecondBuf[~tracksValue][~seqsValue],
@@ -16587,7 +16752,7 @@ voire si la suppression des spec permet de réduire de manière conséquente le 
 	~cen2PatView.value_(~presets[index][\cen2PatView]).doAction;
 
 	~rtmPatSelView.valueAction_(~presets[index][\rtmPatSelView]);
-	~proPatSelView.valueAction_(~presets[index][\proPatSelView]);
+	// ~proPatSelView.valueAction_(~presets[index][\proPatSelView]); // remis plus bas car agit sur le step et l'apparition des données
 	~synPatSelView.valueAction_(~presets[index][\synPatSelView]);
 	~spaPatSelView.valueAction_(~presets[index][\spaPatSelView]);
 	~legPatSelView.valueAction_(~presets[index][\legPatSelView]);
@@ -16614,9 +16779,16 @@ voire si la suppression des spec permet de réduire de manière conséquente le 
 	~rtmTypeView2.valueAction_(~presets[index][\seqType]);
 
 	~proBjorSpec[~tracksValue][~seqsValue] = rtmSeqSpec;
-	~proBjorView.step_(rtmSeqStep).valueAction_(~proBjorSpec[~tracksValue][~seqsValue].unmap(~presets[index][\proBjor])).doAction; // doAction pour mise à jour du Spec & action sur le global
-	~proBjor2View.step_(rtmSeqStep).valueAction_(~proBjorSpec[~tracksValue][~seqsValue].unmap(~presets[index][\proBjor2])).doAction; // doAction pour mise à jour du Spec & action sur le global
+	~proBjorView/*.step_(rtmSeqStep)*/.value_( ~proBjorGridsX /*~proBjorSpec[~tracksValue][~seqsValue].unmap(~presets[index][\proBjor])*/).doAction; // doAction pour mise à jour du Spec & action sur le global
+	~proBjor2View/*.step_(rtmSeqStep)*/.value_(~proBjorGridsY /*~proBjorSpec[~tracksValue][~seqsValue].unmap(~presets[index][\proBjor2])*/).doAction; // doAction pour mise à jour du Spec & action sur le global
 	~proSelectView.value_(~presets[index][\proSelect]).doAction; // doAction -> necessaire pour action sur le global
+
+	if (~presets[index][\proGridsBias].notNil, {~proBjor3View.valueAction_(~presets[index][\proGridsBias]) } );
+	if (~presets[index][\proGridsBias2].notNil, {~proBjor4View.valueAction_(~presets[index][\proGridsBias2]) } );
+	if (~presets[index][\proWeight].notNil, {~proWeightView.valueAction_(~presets[index][\proWeight]) } );
+	if (~presets[index][\proDrumType].notNil, {~proDrumTypeView.valueAction_(~presets[index][\proDrumType]) } );
+
+	~proPatSelView.valueAction_(~presets[index][\proPatSelView]); // était plus haut mais doit agir sur le step et l'apparition des données
 
 	~synTypeView.valueAction_(~presets[index][\synType]);
 	~offRateSecondBufView.valueAction_(~offRateSecondBufSpec.unmap(~presets[index][\offRateSecondBuf]));
@@ -18080,6 +18252,13 @@ case
 
 	~proBjor[track][seq] = ~presets[index][\proBjor];
 	~proBjor2[track][seq] = ~presets[index][\proBjor2];
+
+	~proBjor3[track][seq] = ~presets[index][\proBjor3];
+	~proBjor4[track][seq] = ~presets[index][\proBjor4];
+	~proGridsBias[track][seq] = ~presets[index][\proGridsBias];
+	~proGridsBias2[track][seq] = ~presets[index][\proGridsBias2];
+	~proWeight[track][seq] = ~presets[index][\proWeight];
+	~proDrumType[track][seq] = ~presets[index][\proDrumType];
 
 	~synType[track][seq] = ~presets[index][\synType];
 	~offRateSecondBuf[track][seq] = ~presets[index][\offRateSecondBuf];
@@ -21805,29 +21984,29 @@ u.drawFunc = { d.draw }
 	.action_({ |view| ~proBjor[tr][~seqsValue] = ~proBjorSpec[tr][~seqsValue].map(view.value).asInteger;
 		view.string = "Hit : %".format(~proBjor[tr][~seqsValue]);
 	})
-	.font_(Font("Verdana", 11))
+	.font_(Font("Verdana", 10))
 	.background_(~sliderBackgroundColor)
 	.hilightColor_(~sliderHilightNoColor)
 	.stringColor_(Color.white)
 	.border_(~border)
 	.borderColor_(~borderColor)
-	.step_(1/~pro[tr][~seqsValue].size)
+	// .step_(1/~pro[tr][~seqsValue].size) // retrait car intégration de ~proBjorGridsX qui ne doit pas avoir de step
 	.valueAction_(1)
 	.action_({ |view| var val, seq; if (tr == ~tracksValue and: {~curSeqTrig == 1}, { seq = ~seqsValue },{ seq = ~seqSeq[tr] }); val = ~proBjorSpec[tr][seq].map(view.value).asInteger;
 		case
 		{ ~triggerAllSeqs[tr] == 0} // Séquence de le piste en cours de sélection
 		{
-			~proBjor[tr][seq] = val; ~presetSeqTextViewG[tr][seq].background_(Color.red)
+			~proBjor[tr][seq] = val; ~proBjorGridsX[tr][seq] = view.value.round(0.001); ~presetSeqTextViewG[tr][seq].background_(Color.red)
 		}
 		{ ~triggerAllSeqs[tr] == 1} // toutes les séquences sélectionnées
 		{
 			var sequenceSelected = (~presetSeqStart[tr]..~presetSeqStop[tr]).collect { |i| i };
-			sequenceSelected.do {|i| ~proBjor[tr][i] = ~proBjorSpec[tr][i].map(view.value).asInteger; ~presetSeqTextViewG[tr][i].background_(Color.red) }
+			sequenceSelected.do {|i| ~proBjor[tr][i] = ~proBjorSpec[tr][i].map(view.value).asInteger; ~proBjorGridsX[tr][i] = view.value.round(0.001); ~presetSeqTextViewG[tr][i].background_(Color.red) }
 		}
 		{ ~triggerAllSeqs[tr] == 2} // tous les presets
-		{ ~presetSeqRandList[tr].do {|i| ~proBjor[tr][i] = ~proBjorSpec[tr][i].map(view.value).asInteger; ~presetSeqTextViewG[tr][i].background_(Color.red) } };
+		{ ~presetSeqRandList[tr].do {|i| ~proBjor[tr][i] = ~proBjorSpec[tr][i].map(view.value).asInteger; ~proBjorGridsX[tr][i] = view.value.round(0.001); ~presetSeqTextViewG[tr][i].background_(Color.red) } };
 
-		view.string = "Hit : %".format( val );
+		view.string = "H: %-%".format( val, ~proBjorGridsX[tr][seq] );
 
 		if (~lemurConnected1 == 1 and: {tr == ~tracksValue}, {
 			~lemurAdress1.sendMsg("/ParC/HitM/value", val); ~lemurAdress1.sendMsg("/ParC/HitLed/value", view.value );
@@ -21842,29 +22021,30 @@ u.drawFunc = { d.draw }
 	.action_({ |view| ~proBjor2[tr][~seqsValue] = ~proBjorSpec[tr][~seqsValue].map(view.value).asInteger;
 		view.string = "Off : %".format(~proBjor2[tr][~seqsValue]);
 	})
-	.font_(Font("Verdana", 11))
+	.font_(Font("Verdana", 10))
 	.background_(~sliderBackgroundColor)
 	.hilightColor_(~sliderHilightNoColor)
 	.stringColor_(Color.white)
 	.border_(~border)
 	.borderColor_(~borderColor)
-	.step_(1/~pro[tr][~seqsValue].size)
+	// .step_(1/~pro[tr][~seqsValue].size) // retrait car intégration de ~proBjorGridsX qui ne doit pas avoir de step
+	.valueAction_(1)
 	.valueAction_(1)
 	.action_({ |view| var val, seq; if (tr == ~tracksValue and: {~curSeqTrig == 1}, { seq = ~seqsValue },{ seq = ~seqSeq[tr] }); val = ~proBjorSpec[tr][seq].map(view.value).asInteger;
 		case
 		{ ~triggerAllSeqs[tr] == 0} // Séquence de le piste en cours de sélection
 		{
-			~proBjor2[tr][seq] = val; ~presetSeqTextViewG[tr][seq].background_(Color.red)
+			~proBjor2[tr][seq] = val; ~proBjorGridsY[tr][seq] = view.value.round(0.001); ~presetSeqTextViewG[tr][seq].background_(Color.red)
 		}
 		{ ~triggerAllSeqs[tr] == 1} // toutes les séquences sélectionnées
 		{
 			var sequenceSelected = (~presetSeqStart[tr]..~presetSeqStop[tr]).collect { |i| i };
-			sequenceSelected.do {|i| ~proBjor2[tr][i] = ~proBjorSpec[tr][i].map(view.value).asInteger; ~presetSeqTextViewG[tr][i].background_(Color.red) }
+			sequenceSelected.do {|i| ~proBjor2[tr][i] = ~proBjorSpec[tr][i].map(view.value).asInteger; ~proBjorGridsY[tr][i] = view.value.round(0.001); ~presetSeqTextViewG[tr][i].background_(Color.red) }
 		}
 		{ ~triggerAllSeqs[tr] == 2} // tous les presets
-		{ ~presetSeqRandList[tr].do {|i| ~proBjor2[tr][i] = ~proBjorSpec[tr][i].map(view.value).asInteger; ~presetSeqTextViewG[tr][i].background_(Color.red) } };
+		{ ~presetSeqRandList[tr].do {|i| ~proBjor2[tr][i] = ~proBjorSpec[tr][i].map(view.value).asInteger; ~proBjorGridsY[tr][i] = view.value.round(0.001); ~presetSeqTextViewG[tr][i].background_(Color.red) } };
 
-		view.string = "Off : %".format( val );
+		view.string = "O: %-%".format( val, ~proBjorGridsY[tr][seq] );
 
 		if (~lemurConnected1 == 1 and: {tr == ~tracksValue}, {
 			~lemurAdress1.sendMsg("/ParC/OffM/value", val); ~lemurAdress1.sendMsg("/ParC/OffLed/value", view.value );
@@ -22144,15 +22324,15 @@ u.drawFunc = { d.draw }
 			case
 			{ ~triggerAllSeqs[tr] == 0} // Séquence de le piste en cours de sélection
 			{
-				~proMul[tr][seq] = val; {~presetSeqTextViewG[tr][seq].background_(Color.red)}.defer;
+				~proMul[tr][seq] = val; ~gridsDens[tr][seq] = view.value; {~presetSeqTextViewG[tr][seq].background_(Color.red)}.defer;
 			}
 			{ ~triggerAllSeqs[tr] == 1} // toutes les séquences sélectionnées
 			{
 				var sequenceSelected = (~presetSeqStart[tr]..~presetSeqStop[tr]).collect { |i| i };
-				sequenceSelected.do {|i| ~proMul[tr][i] = val; {~presetSeqTextViewG[tr][i].background_(Color.red)}.defer }
+				sequenceSelected.do {|i| ~proMul[tr][i] = val; ~gridsDens[tr][i] = view.value; {~presetSeqTextViewG[tr][i].background_(Color.red)}.defer }
 			}
 			{ ~triggerAllSeqs[tr] == 2} // tous les presets
-			{ ~presetSeqRandList[tr].do {|i| ~proMul[tr][i] = val; {~presetSeqTextViewG[tr][i].background_(Color.red)}.defer } };
+			{ ~presetSeqRandList[tr].do {|i| ~proMul[tr][i] = val; ~gridsDens[tr][i] = view.value; {~presetSeqTextViewG[tr][i].background_(Color.red)}.defer } };
 
 			view.string = "Pro : %".format( val );
 
@@ -22174,15 +22354,15 @@ u.drawFunc = { d.draw }
 				case
 				{ ~triggerAllSeqs[tr] == 0} // Séquence de le piste en cours de sélection
 				{
-					~proMul[tr][seq] = val; {~presetSeqTextViewG[tr][seq].background_(Color.red)}.defer;
+					~proMul[tr][seq] = val; ~gridsDens[tr][seq] = view.value; {~presetSeqTextViewG[tr][seq].background_(Color.red)}.defer;
 				}
 				{ ~triggerAllSeqs[tr] == 1} // toutes les séquences sélectionnées
 				{
 					var sequenceSelected = (~presetSeqStart[tr]..~presetSeqStop[tr]).collect { |i| i };
-					sequenceSelected.do {|i| ~proMul[tr][i] = val; {~presetSeqTextViewG[tr][i].background_(Color.red)}.defer }
+					sequenceSelected.do {|i| ~proMul[tr][i] = val; ~gridsDens[tr][i] = view.value; {~presetSeqTextViewG[tr][i].background_(Color.red)}.defer }
 				}
 				{ ~triggerAllSeqs[tr] == 2} // tous les presets
-				{ ~presetSeqRandList[tr].do {|i| ~proMul[tr][i] = val; {~presetSeqTextViewG[tr][i].background_(Color.red)}.defer } };
+				{ ~presetSeqRandList[tr].do {|i| ~proMul[tr][i] = val; ~gridsDens[tr][i] = view.value; {~presetSeqTextViewG[tr][i].background_(Color.red)}.defer } };
 
 				view.string = "Pro : %".format( val );
 
@@ -22684,11 +22864,19 @@ u.drawFunc = { d.draw }
 	});
 });
 
-~proBjorView.action_({ |view| ~proBjor[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.map(view.value).asInteger;
-	// 2 mises à jour successives : [~seqSeq[~tracksValue]] donne une première bonne valeur, alors [~seqsValue] donne une première mauvaise valeur qui est bien updaté par la suite
-	view.string = "Hit : %".format(~proBjor[~tracksValue][~seqsValue]);
+~proBjorView.action_({ |view| ~proBjor[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue].map(view.value).asInteger;
+	// 2 mises à jour successives : [~seqSeq[~tracksValue]] donne une première bonne valeur, alors [~seqsValue] donne une première mauvaise valeur qui est bien updaté par la suite -> arrêté car ne donne pas de bonnes valeurs avec Arm
+	~proBjorGridsX[~tracksValue][~seqsValue] = view.value.round(0.001);
+
+	if (~proPatSel[~tracksValue][~seqsValue] > 18 /*and: {~proPat[~tracksValue][~seqsValue] == 1}*/, {
+		view.string = "GX : %".format(~proBjorGridsX[~tracksValue][~seqsValue]); ~drawSCGrids.();
+	}, {
+		view.string = "Hit : %".format(~proBjor[~tracksValue][~seqsValue]);
+	});
 	// Action sur le global
-	~proBjorViewG[~tracksValue].step_(1/~pro[~tracksValue][~seqsValue].size).value_(~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.unmap(~proBjor[~tracksValue][~seqsValue])).string = "Hit : %".format(~proBjor[~tracksValue][~seqsValue]);
+	// ~proBjorViewG[~tracksValue].step_(1/~pro[~tracksValue][~seqsValue].size).value_(~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.unmap(~proBjor[~tracksValue][~seqsValue])).string = "Hit : %".format(~proBjor[~tracksValue][~seqsValue]);
+	// ~proBjorViewG[~tracksValue].step_(0.001).value_(~proBjorGridsX[~tracksValue][~seqsValue]).string = "GX : %".format(~proBjorGridsX[~tracksValue][~seqsValue]);
+	~proBjorViewG[~tracksValue].value_(~proBjorGridsX[~tracksValue][~seqsValue]).string = "H: %-%".format(~proBjor[~tracksValue][~seqsValue], ~proBjorGridsX[~tracksValue][~seqsValue]);
 
 	if (~lemurConnected1 == 1, {
 		~lemurAdress1.sendMsg("/ParC/HitM/value", ~proBjor[~tracksValue][~seqsValue]);
@@ -22700,11 +22888,19 @@ u.drawFunc = { d.draw }
 	});
 });
 
-~proBjor2View.action_({ |view| ~proBjor2[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.map(view.value).asInteger;
-	// 2 mises à jour successives : [~seqSeq[~tracksValue]] donne une première bonne valeur, alors [~seqsValue] donne une première mauvaise valeur qui est bien updaté par la suite
-	view.string = "Off : %".format(~proBjor2[~tracksValue][~seqsValue]);
-	// Action asur le global
-	~proBjor2ViewG[~tracksValue].step_(1/~pro[~tracksValue][~seqsValue].size).value_(~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.unmap(~proBjor2[~tracksValue][~seqsValue])).string = "Off : %".format(~proBjor2[~tracksValue][~seqsValue]);
+~proBjor2View.action_({ |view| ~proBjor2[~tracksValue][~seqsValue] = ~proBjorSpec[~tracksValue]/*[~seqSeq[~tracksValue]]*/[~seqsValue].map(view.value).asInteger;
+	// 2 mises à jour successives : [~seqSeq[~tracksValue]] donne une première bonne valeur, alors [~seqsValue] donne une première mauvaise valeur qui est bien updaté par la suite -> arrêté car ne donne pas de bonnes valeurs avec Arm
+	~proBjorGridsY[~tracksValue][~seqsValue] = view.value.round(0.001);
+
+	if (~proPatSel[~tracksValue][~seqsValue] > 18 /*and: {~proPat[~tracksValue][~seqsValue] == 1}*/, {
+		view.string = "GY : %".format(~proBjorGridsY[~tracksValue][~seqsValue]); ~drawSCGrids.();
+	}, {
+		view.string = "Off : %".format(~proBjor2[~tracksValue][~seqsValue]);
+	});
+	// Action sur le global
+	// ~proBjor2ViewG[~tracksValue].step_(1/~pro[~tracksValue][~seqsValue].size).value_(~proBjorSpec[~tracksValue][~seqSeq[~tracksValue]]/*[~seqsValue]*/.unmap(~proBjor2[~tracksValue][~seqsValue])).string = "Off : %".format(~proBjor2[~tracksValue][~seqsValue]);
+	// ~proBjor2ViewG[~tracksValue].step_(0.001).value_(~proBjorGridsY[~tracksValue][~seqsValue]).string = "GY : %".format(~proBjorGridsY[~tracksValue][~seqsValue]);
+	~proBjor2ViewG[~tracksValue].value_(~proBjorGridsY[~tracksValue][~seqsValue]).string = "O: %-%".format(~proBjor2[~tracksValue][~seqsValue], ~proBjorGridsY[~tracksValue][~seqsValue]);
 
 	if (~lemurConnected1 == 1, {
 		~lemurAdress1.sendMsg("/ParC/OffM/value", ~proBjor2[~tracksValue][~seqsValue]);
@@ -22760,8 +22956,10 @@ u.drawFunc = { d.draw }
 	});
 }).doAction;
 
+~gridsDens = 0 ! ~nbOfSeqs ! ~nbOfTracksX2;
+
 // Intégration du multiplicateur dans le .map
-~proMulView.action_({ |view| ~proMul[~tracksValue][~seqsValue] = ~proMulSpec.map(view.value);
+~proMulView.action_({ |view| ~proMul[~tracksValue][~seqsValue] = ~proMulSpec.map(view.value); ~gridsDens[~tracksValue][~seqsValue] = view.value;
 	view.string = "%".format(~proMul[~tracksValue][~seqsValue]);
 	// ~proRangeView.string_("%\n to \n%".format((~proMax[~tracksValue][~seqsValue]).round(~proRound[~tracksValue][~seqsValue]), (~proMin[~tracksValue][~seqsValue]).round(~proRound[~tracksValue][~seqsValue])));
 	~proIndexView.string_("At : %".format((~proSpec[~tracksValue][~seqsValue].map(~proIndexView.value * ~proMul[~tracksValue][~seqsValue])).round(~proRound[~tracksValue][~seqsValue]))); // léger pb de rounding ?
@@ -30862,7 +31060,9 @@ PopUpMenu.defaultKeyDownAction
 			// Dans le Tab d'effets
 			~nbOfServers.collect {|s| ~fxInSerieListView[s]},
 
-			~rySpaTypeTrackView, if (~acousItems.notNil, {~acousTypeSensView}, {~rySpaTypeTrackView}) // ListView
+			~rySpaTypeTrackView, if (~acousItems.notNil, {~acousTypeSensView}, {~rySpaTypeTrackView}), // ListView
+
+			~proDrumTypeView
 
 		].flatten(2).do {|i| i.canFocus = focus; i.focus(false); /*pour désélectionner le dernier*/
 			// i.acceptsMouseOver = focus; i.mouseOverAction = {};
@@ -30878,7 +31078,7 @@ PopUpMenu.defaultKeyDownAction
 		[~trackAllVolView, ~trackInVolView, ~trackFXVolView, ~trackVolView,
 			~toTempoView, ~toSecView, ~gblSeqIndexView, ~gblSeqView, ~nbTotalBeatsView,
 			~seqIndexView, ~harIndexView, ~nbEventView,
-			~proBjorView, ~proBjor2View, ~offRateSecondBufView, ~ampRatView, ~aAmpView, ~offThreshView, ~freqRatView, ~fAmpView, ~psPitchDispersView, ~psTimeDispersView, ~psWindowSizeView, ~pAmpView, ~panRatView,
+			~proBjorView, ~proBjor2View, ~proBjor3View, ~proBjor4View, ~proWeightView, ~offRateSecondBufView, ~ampRatView, ~aAmpView, ~offThreshView, ~freqRatView, ~fAmpView, ~psPitchDispersView, ~psTimeDispersView, ~psWindowSizeView, ~pAmpView, ~panRatView,
 			~pFadeView, ~pFadeViewG, ~quantView, ~quantViewG,
 			// ~mixAllFxView2[0], ~lagTimeAllFxView2[0], ~fadeTimeSynthFxView2[0], ~nbOfServers.collect {|s|
 			~nbOfServers.collect {|s| ~mixAllFxView2[s]}, ~nbOfServers.collect {|s| ~lagTimeAllFxView2[s]}, ~nbOfServers.collect {|s| ~fadeTimeSynthFxView2[s]},

--- a/L4L_Project/_3_Init_Pattern_182.scd
+++ b/L4L_Project/_3_Init_Pattern_182.scd
@@ -197,12 +197,12 @@ if (~serverFX == 1, {
 
 
 // Numéro des bus de contrôle Rat...
-~controlBus0 = 47 /*45*/;
-~controlBus1 = 48 /*46*/;
-~controlBus2 = 49 /*47*/;
-~controlBus3 = 50 /*48*/;
-~controlBus4 = 51 /*49*/;
-~controlBus5 = 52 /*50*/;
+~controlBus0 = 49 /*45*/;
+~controlBus1 = 50 /*46*/;
+~controlBus2 = 51 /*47*/;
+~controlBus3 = 52 /*48*/;
+~controlBus4 = 53 /*49*/;
+~controlBus5 = 54 /*50*/;
 
 
 
@@ -436,6 +436,30 @@ envir[key][track][seq] = value;
 
 
 
+~patternKeyRand0ElementFunction = { | envir, track, seq, key, pos, block, stream |
+	block{|break|
+		key.envirGet[track][seq].size.do{|i|
+			if (block.envirGet[track] == 1, {break.value}, {
+				r = stream.next;
+				envir[pos][track][seq] = 0;
+				r.yield;
+			})
+		}
+	}
+};
+
+~patternKeyRand0ElementCutLoopFunction = { | envir, track, seq, key, pos, block, stream |
+	envir[block][track] = 0; block{|break|
+		~seqGlobalRemainingSize[track].do{|i|
+			if (block.envirGet[track] == 1, {break.value}, {
+				r = stream.next;
+				envir[pos][track][seq] = 0;
+				r.yield;
+			})
+		}
+	}
+};
+
 ~patternKeyRand1ElementFunction = { | envir, track, seq, key, pos, block, selection, stream |
 	block{|break|
 		key.envirGet[track][seq].size.do{|i|
@@ -591,35 +615,37 @@ envir[key][track][seq] = value;
 	{pat.envirGet[track][seq] == 0 or: { patSel.envirGet[track][seq] < 17 }} { ev[key] }
 	{patSel.envirGet[track][seq] == 17 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.durU } // ~posRat[track][seq] = 0; // nécessaire sinon décalage ??? Au moins pour le Repérage
 	{patSel.envirGet[track][seq] == 18 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.durU }
-	{patSel.envirGet[track][seq] == 19 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.legU }
-	{patSel.envirGet[track][seq] == 20 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.legU }
-	{patSel.envirGet[track][seq] == 21 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.ampU }
-	{patSel.envirGet[track][seq] == 22 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.ampU }
-	{patSel.envirGet[track][seq] == 23 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.preprateU }
-	{patSel.envirGet[track][seq] == 24 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.preprateU }
-	{patSel.envirGet[track][seq] == 25 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.stretcherU }
-	{patSel.envirGet[track][seq] == 26 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.stretcherU }
-	{patSel.envirGet[track][seq] == 27 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.centerU }
-	{patSel.envirGet[track][seq] == 28 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.centerU }
-	{patSel.envirGet[track][seq] == 29 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.preprate2U }
-	{patSel.envirGet[track][seq] == 30 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.preprate2U }
-	{patSel.envirGet[track][seq] == 31 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.stretcher2U }
-	{patSel.envirGet[track][seq] == 32 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.stretcher2U }
-	{patSel.envirGet[track][seq] == 33 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.center2U }
-	{patSel.envirGet[track][seq] == 34 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.center2U }
-	{patSel.envirGet[track][seq] == 35 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.prepbufU }
-	{patSel.envirGet[track][seq] == 36 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.prepbufU }
-	{patSel.envirGet[track][seq] == 37 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.offsetU }
-	{patSel.envirGet[track][seq] == 38 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.offsetU }
-	{patSel.envirGet[track][seq] == 39 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.panU }
-	{patSel.envirGet[track][seq] == 40 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.panU }
-	{patSel.envirGet[track][seq] == 41 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.delayU }
-	{patSel.envirGet[track][seq] == 42 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.delayU }
-	{patSel.envirGet[track][seq] == 43 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.prepoutLU }
-	{patSel.envirGet[track][seq] == 44 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.prepoutLU }
-	{patSel.envirGet[track][seq] == 45 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.prepoutRU }
-	{patSel.envirGet[track][seq] == 46 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.prepoutRU }
-	{patSel.envirGet[track][seq] > 46 /*and: { ~legPat[track][seq] == 1 }*/} { envir[pos][track][seq] = 100000; }
+	{patSel.envirGet[track][seq] == 19 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.prepproU }
+	{patSel.envirGet[track][seq] == 20 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.prepproU }
+	{patSel.envirGet[track][seq] == 21 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.legU }
+	{patSel.envirGet[track][seq] == 22 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.legU }
+	{patSel.envirGet[track][seq] == 23 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.ampU }
+	{patSel.envirGet[track][seq] == 24 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.ampU }
+	{patSel.envirGet[track][seq] == 25 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.preprateU }
+	{patSel.envirGet[track][seq] == 26 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.preprateU }
+	{patSel.envirGet[track][seq] == 27 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.stretcherU }
+	{patSel.envirGet[track][seq] == 28 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.stretcherU }
+	{patSel.envirGet[track][seq] == 29 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.centerU }
+	{patSel.envirGet[track][seq] == 30 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.centerU }
+	{patSel.envirGet[track][seq] == 31 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.preprate2U }
+	{patSel.envirGet[track][seq] == 32 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.preprate2U }
+	{patSel.envirGet[track][seq] == 33 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.stretcher2U }
+	{patSel.envirGet[track][seq] == 34 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.stretcher2U }
+	{patSel.envirGet[track][seq] == 35 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.center2U }
+	{patSel.envirGet[track][seq] == 36 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.center2U }
+	{patSel.envirGet[track][seq] == 37 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.prepbufU }
+	{patSel.envirGet[track][seq] == 38 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.prepbufU }
+	{patSel.envirGet[track][seq] == 39 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.offsetU }
+	{patSel.envirGet[track][seq] == 40 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.offsetU }
+	{patSel.envirGet[track][seq] == 41 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.panU }
+	{patSel.envirGet[track][seq] == 42 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.panU }
+	{patSel.envirGet[track][seq] == 43 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.delayU }
+	{patSel.envirGet[track][seq] == 44 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.delayU }
+	{patSel.envirGet[track][seq] == 45 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.prepoutLU }
+	{patSel.envirGet[track][seq] == 46 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.prepoutLU }
+	{patSel.envirGet[track][seq] == 47 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; ev.prepoutRU }
+	{patSel.envirGet[track][seq] == 48 and: { pat.envirGet[track][seq] == 1 }} { envir[pos][track][seq] = 1000; 1-ev.prepoutRU }
+	{patSel.envirGet[track][seq] > 48 /*and: { ~legPat[track][seq] == 1 }*/} { envir[pos][track][seq] = 100000; }
 };
 
 
@@ -1603,311 +1629,311 @@ envir[key][track][seq] = value;
 				{ev.delayUElev != 90} { 0 }
 			}))
 
-	/*
-	\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
-	\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
-
-	// panning circulaire multiple - permet de sélectionner si panning circulaire régulier ou accélérant ou déccélérant - pas utile pour circ unique
-	\spaSpeed, (Pfunc({ |ev|
-	ev.prepspa.collect { |i|
-	case
-	/*{i.inclusivelyBetween(2,3)} // pour les lines Aller ou Aller/retour
-	{0}*/
-	{i.inclusivelyBetween(4,5)} // pour les lines Aller ou Aller/retour
-	{1}
-	/*{i.inclusivelyBetween(8,9)} // Circ multiple régulier
-	{0}*/
-	{i.inclusivelyBetween(10,11)} // Circ multiple Acc
-	{1}
-	{i.inclusivelyBetween(12,13)} // Circ multiple Decc
-	{2}
-	{i >= 0 /*.inclusivelyBetween(6,7)*/} // Circ unique & autres
-	{0}
-	}
-	})) /*.trace(prefix: "spaSpeed -> ")*/,
-	*/
-
-),
-
-vmSt: Pbind(
-
-	\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
-	\speakerRadius, (Pfunc({ ~speakRad[track][~seqSeq[track]] }) ) /*.trace(prefix: "speakerRadius -> ")*/,
-	\pointScale, (Pfunc({ ~vmPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
-
-	/*
-	// Pour effectuer les trajectoires Gauche / Droite - seulement utile pour les lines
-	\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
-	\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
-
-	// seulement utile pour les lines Aller ou Aller/retour
-	\spaSpeed, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.inclusivelyBetween(2,3), {0}, {1} ) } }) ),
-	*/
-
-),
-
-vmSD: Pbind(
-
-	\outSpa, (Pkey(\prepfxL) * ~fxMulChannel) /*.trace(prefix: "outSpa -> ")*/,
-
-	\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
-	\speakerRadius, (Pfunc({ ~speakRad[track][~seqSeq[track]] }) ) /*.trace(prefix: "speakerRadius -> ")*/,
-	\pointScale, (Pfunc({ ~vmPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
-	\orientation, (Pfunc({ ~orientation[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
-
-	// ci-dessous pour le circulaire selon données spectrales
-	\freqMin, Pfunc({ ~sdFreqRangeMin[track][~seqSeq[track]] }),
-	\freqMax, Pfunc({ ~sdFreqRangeMax[track][~seqSeq[track]] }),
-	\freqCurve, Pfunc({ ~spaLagCurve[track][~seqSeq[track]] }),
-	\dbMin, Pfunc({ ~sdDbRangeMin[track][~seqSeq[track]] }),
-	\dbMax, Pfunc({ ~sdDbRangeMax[track][~seqSeq[track]] }),
-
-	\spaLagTime, Pfunc({ ~spaLagTime[track][~seqSeq[track]] }) // juste pour le lissage des spatialisations liées à l'analyse des paramètres spectraux ou d'intensité
-
-	/*
-	// Pour effectuer les trajectoires Gauche / Droite
-	\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
-	\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
-	*/
-
-),
-
-vmTraj: Pbind(
-
-	\outSpa, (Pkey(\prepfxL) * ~fxMulChannel) /*.trace(prefix: "outSpa -> ")*/,
-
-	\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
-	\speakerRadius, (Pfunc({ ~speakRad[track][~seqSeq[track]] }) ) /*.trace(prefix: "speakerRadius -> ")*/,
-	\pointScale, (Pfunc({ ~vmPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
-	\orientation, (Pfunc({ ~orientation[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
-
-	\trajBufLoop, Pfunc({ ~trajSpatLoop[track][~seqSeq[track]] }) /*.trace(prefix: "trajBufLoop -> ")*/,
-
-	/*
-	\prepspa3, (Pfunc({ |ev| ev.prepspa.collect { |i| i - 18 } })) /*.trace(prefix: "prepspa3 -> ")*/,
-	\trajBuf, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][0] }, { ~trajectoryBuffers[i][0] }) } })) /*.trace(prefix: "trajBuf -> ")*/,
-	// Durée réelle de la trajectoire du buffer
-	\trajBufDur, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][1] }, { ~trajectoryBuffers[i][1] }) } })) /*.trace(prefix: "trajBufDur -> ")*/,
-	*/
-
-	// avant ev.trajBufDur et non ev.trajBufDur[0]
-	// -> Comment faire ??????
-	\trajBufRatio, (Pfunc({ |ev| var seq = ~seqSeq[track];
-		case
-		{~trajSpatTimeType[track][seq] == 0} // Adapt Time
-		{ (ev.durenv / ev.trajBufDur).reciprocal }
-		{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ > ev.trajBufDur0/*[0]*/}} // Trajectory Time
-		{ (ev.durenv / ev.trajBufDur).reciprocal }
-		{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ <= ev.trajBufDur0/*[0]*/}} // Trajectory Time
-		{ 1 }
-		{~trajSpatTimeType[track][seq] == 2 } // Slider Time
-		{ /*ev.trajBufRat*/ ~trajSpatRate[track][seq] }
-	})) /*.trace(prefix: "trajBufRatio -> ")*/
-
-),
-
-vbSD: Pbind(
+			/*
+			\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
+			\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
+
+			// panning circulaire multiple - permet de sélectionner si panning circulaire régulier ou accélérant ou déccélérant - pas utile pour circ unique
+			\spaSpeed, (Pfunc({ |ev|
+			ev.prepspa.collect { |i|
+			case
+			/*{i.inclusivelyBetween(2,3)} // pour les lines Aller ou Aller/retour
+			{0}*/
+			{i.inclusivelyBetween(4,5)} // pour les lines Aller ou Aller/retour
+			{1}
+			/*{i.inclusivelyBetween(8,9)} // Circ multiple régulier
+			{0}*/
+			{i.inclusivelyBetween(10,11)} // Circ multiple Acc
+			{1}
+			{i.inclusivelyBetween(12,13)} // Circ multiple Decc
+			{2}
+			{i >= 0 /*.inclusivelyBetween(6,7)*/} // Circ unique & autres
+			{0}
+			}
+			})) /*.trace(prefix: "spaSpeed -> ")*/,
+			*/
+
+		),
+
+		vmSt: Pbind(
+
+			\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
+			\speakerRadius, (Pfunc({ ~speakRad[track][~seqSeq[track]] }) ) /*.trace(prefix: "speakerRadius -> ")*/,
+			\pointScale, (Pfunc({ ~vmPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
+
+			/*
+			// Pour effectuer les trajectoires Gauche / Droite - seulement utile pour les lines
+			\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
+			\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
+
+			// seulement utile pour les lines Aller ou Aller/retour
+			\spaSpeed, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.inclusivelyBetween(2,3), {0}, {1} ) } }) ),
+			*/
+
+		),
+
+		vmSD: Pbind(
+
+			\outSpa, (Pkey(\prepfxL) * ~fxMulChannel) /*.trace(prefix: "outSpa -> ")*/,
+
+			\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
+			\speakerRadius, (Pfunc({ ~speakRad[track][~seqSeq[track]] }) ) /*.trace(prefix: "speakerRadius -> ")*/,
+			\pointScale, (Pfunc({ ~vmPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
+			\orientation, (Pfunc({ ~orientation[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
+
+			// ci-dessous pour le circulaire selon données spectrales
+			\freqMin, Pfunc({ ~sdFreqRangeMin[track][~seqSeq[track]] }),
+			\freqMax, Pfunc({ ~sdFreqRangeMax[track][~seqSeq[track]] }),
+			\freqCurve, Pfunc({ ~spaLagCurve[track][~seqSeq[track]] }),
+			\dbMin, Pfunc({ ~sdDbRangeMin[track][~seqSeq[track]] }),
+			\dbMax, Pfunc({ ~sdDbRangeMax[track][~seqSeq[track]] }),
+
+			\spaLagTime, Pfunc({ ~spaLagTime[track][~seqSeq[track]] }) // juste pour le lissage des spatialisations liées à l'analyse des paramètres spectraux ou d'intensité
+
+			/*
+			// Pour effectuer les trajectoires Gauche / Droite
+			\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
+			\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
+			*/
+
+		),
+
+		vmTraj: Pbind(
+
+			\outSpa, (Pkey(\prepfxL) * ~fxMulChannel) /*.trace(prefix: "outSpa -> ")*/,
+
+			\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
+			\speakerRadius, (Pfunc({ ~speakRad[track][~seqSeq[track]] }) ) /*.trace(prefix: "speakerRadius -> ")*/,
+			\pointScale, (Pfunc({ ~vmPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
+			\orientation, (Pfunc({ ~orientation[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
+
+			\trajBufLoop, Pfunc({ ~trajSpatLoop[track][~seqSeq[track]] }) /*.trace(prefix: "trajBufLoop -> ")*/,
+
+			/*
+			\prepspa3, (Pfunc({ |ev| ev.prepspa.collect { |i| i - 18 } })) /*.trace(prefix: "prepspa3 -> ")*/,
+			\trajBuf, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][0] }, { ~trajectoryBuffers[i][0] }) } })) /*.trace(prefix: "trajBuf -> ")*/,
+			// Durée réelle de la trajectoire du buffer
+			\trajBufDur, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][1] }, { ~trajectoryBuffers[i][1] }) } })) /*.trace(prefix: "trajBufDur -> ")*/,
+			*/
+
+			// avant ev.trajBufDur et non ev.trajBufDur[0]
+			// -> Comment faire ??????
+			\trajBufRatio, (Pfunc({ |ev| var seq = ~seqSeq[track];
+				case
+				{~trajSpatTimeType[track][seq] == 0} // Adapt Time
+				{ (ev.durenv / ev.trajBufDur).reciprocal }
+				{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ > ev.trajBufDur0/*[0]*/}} // Trajectory Time
+				{ (ev.durenv / ev.trajBufDur).reciprocal }
+				{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ <= ev.trajBufDur0/*[0]*/}} // Trajectory Time
+				{ 1 }
+				{~trajSpatTimeType[track][seq] == 2 } // Slider Time
+				{ /*ev.trajBufRat*/ ~trajSpatRate[track][seq] }
+			})) /*.trace(prefix: "trajBufRatio -> ")*/
+
+		),
+
+		vbSD: Pbind(
 
-	\outSpa, (Pkey(\prepfxL) * ~fxMulChannel)/*.trace(prefix: "outSpa -> ")*/,
+			\outSpa, (Pkey(\prepfxL) * ~fxMulChannel)/*.trace(prefix: "outSpa -> ")*/,
 
-	\spread, Pfunc({ ~vbapSpread[track][~seqSeq[track]] }), // Spread du VBAP
-	\x2Off, Pfunc({ ~vbapX2Off[track][~seqSeq[track]] }),
+			\spread, Pfunc({ ~vbapSpread[track][~seqSeq[track]] }), // Spread du VBAP
+			\x2Off, Pfunc({ ~vbapX2Off[track][~seqSeq[track]] }),
 
-	// ci-dessous pour VBAP Distance
-	\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
-	\pointScale, (Pfunc({ ~vbPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
+			// ci-dessous pour VBAP Distance
+			\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
+			\pointScale, (Pfunc({ ~vbPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
 
-	\delayUElev, (Pfunc({ |ev| ev.delayX.range(0, 90) })),
-	\selElev, (Pfunc({ |ev| case
-		{ev.delayUElev == 0} { 1 }
-		{ev.delayUElev == 90} { 2 }
-		{ev.delayUElev != 90} { 0 }
-	})),
+			\delayUElev, (Pfunc({ |ev| ev.delayX.range(0, 90) })),
+			\selElev, (Pfunc({ |ev| case
+				{ev.delayUElev == 0} { 1 }
+				{ev.delayUElev == 90} { 2 }
+				{ev.delayUElev != 90} { 0 }
+			})),
 
-	// ci-dessous pour le circulaire selon données spectrales
-	\freqMin, Pfunc({ ~sdFreqRangeMin[track][~seqSeq[track]] }),
-	\freqMax, Pfunc({ ~sdFreqRangeMax[track][~seqSeq[track]] }),
-	\freqCurve, Pfunc({ ~spaLagCurve[track][~seqSeq[track]] }),
-	\dbMin, Pfunc({ ~sdDbRangeMin[track][~seqSeq[track]] }),
-	\dbMax, Pfunc({ ~sdDbRangeMax[track][~seqSeq[track]] }),
+			// ci-dessous pour le circulaire selon données spectrales
+			\freqMin, Pfunc({ ~sdFreqRangeMin[track][~seqSeq[track]] }),
+			\freqMax, Pfunc({ ~sdFreqRangeMax[track][~seqSeq[track]] }),
+			\freqCurve, Pfunc({ ~spaLagCurve[track][~seqSeq[track]] }),
+			\dbMin, Pfunc({ ~sdDbRangeMin[track][~seqSeq[track]] }),
+			\dbMax, Pfunc({ ~sdDbRangeMax[track][~seqSeq[track]] }),
 
-	\spaLagTime, Pfunc({ ~spaLagTime[track][~seqSeq[track]] }) // juste pour le lissage des spatialisations liées à l'analyse des paramètres spectraux ou d'intensité
-
-	/*
-	// Pour effectuer les trajectoires Gauche / Droite
-	\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
-	\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
-	*/
-
-),
-
-vbTraj: Pbind(
-
-	\outSpa, (Pkey(\prepfxL) * ~fxMulChannel) /*.trace(prefix: "outSpa -> ")*/,
-
-	\spread, Pfunc({ ~vbapSpread[track][~seqSeq[track]] }), // Spread du VBAP
-
-	\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
-	\pointScale, (Pfunc({ ~vbPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
+			\spaLagTime, Pfunc({ ~spaLagTime[track][~seqSeq[track]] }) // juste pour le lissage des spatialisations liées à l'analyse des paramètres spectraux ou d'intensité
+
+			/*
+			// Pour effectuer les trajectoires Gauche / Droite
+			\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
+			\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
+			*/
+
+		),
+
+		vbTraj: Pbind(
+
+			\outSpa, (Pkey(\prepfxL) * ~fxMulChannel) /*.trace(prefix: "outSpa -> ")*/,
+
+			\spread, Pfunc({ ~vbapSpread[track][~seqSeq[track]] }), // Spread du VBAP
+
+			\dbRollOff, (Pfunc({ ~dbRollOff[track][~seqSeq[track]] }) ) /*.trace(prefix: "dbRollOff -> ")*/,
+			\pointScale, (Pfunc({ ~vbPointScale[track][~seqSeq[track]] }) ) /*.trace(prefix: "pointScale -> ")*/,
 
-	\trajBufLoop, Pfunc({ ~trajSpatLoop[track][~seqSeq[track]] }) /*.trace(prefix: "trajBufLoop -> ")*/,
+			\trajBufLoop, Pfunc({ ~trajSpatLoop[track][~seqSeq[track]] }) /*.trace(prefix: "trajBufLoop -> ")*/,
 
-	/*
-	\prepspa3, (Pfunc({ |ev| ev.prepspa.collect { |i| i - 18 } })) /*.trace(prefix: "prepspa3 -> ")*/,
-	\trajBuf, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][0] }, { ~trajectoryBuffers[i][0] }) } })) /*.trace(prefix: "trajBuf -> ")*/,
-	// Durée réelle de la trajectoire du buffer
-	\trajBufDur, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][1] }, { ~trajectoryBuffers[i][1] }) } })) /*.trace(prefix: "trajBufDur -> ")*/,
-	*/
+			/*
+			\prepspa3, (Pfunc({ |ev| ev.prepspa.collect { |i| i - 18 } })) /*.trace(prefix: "prepspa3 -> ")*/,
+			\trajBuf, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][0] }, { ~trajectoryBuffers[i][0] }) } })) /*.trace(prefix: "trajBuf -> ")*/,
+			// Durée réelle de la trajectoire du buffer
+			\trajBufDur, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][1] }, { ~trajectoryBuffers[i][1] }) } })) /*.trace(prefix: "trajBufDur -> ")*/,
+			*/
 
-	\trajBufRatio, (Pfunc({ |ev| var seq = ~seqSeq[track];
-		case
-		{~trajSpatTimeType[track][seq] == 0} // Adapt Time
-		{ (ev.durenv / ev.trajBufDur).reciprocal }
-		{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ > ev.trajBufDur0/*[0]*/}} // Trajectory Time
-		{ (ev.durenv / ev.trajBufDur).reciprocal }
-		{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ <= ev.trajBufDur0/*[0]*/}} // Trajectory Time
-		{ 1 }
-		{~trajSpatTimeType[track][seq] == 2 } // Slider Time
-		{ /*ev.trajBufRat*/ ~trajSpatRate[track][seq] }
-	})), /*.trace(prefix: "trajBufRatio -> ")*/
+			\trajBufRatio, (Pfunc({ |ev| var seq = ~seqSeq[track];
+				case
+				{~trajSpatTimeType[track][seq] == 0} // Adapt Time
+				{ (ev.durenv / ev.trajBufDur).reciprocal }
+				{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ > ev.trajBufDur0/*[0]*/}} // Trajectory Time
+				{ (ev.durenv / ev.trajBufDur).reciprocal }
+				{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ <= ev.trajBufDur0/*[0]*/}} // Trajectory Time
+				{ 1 }
+				{~trajSpatTimeType[track][seq] == 2 } // Slider Time
+				{ /*ev.trajBufRat*/ ~trajSpatRate[track][seq] }
+			})), /*.trace(prefix: "trajBufRatio -> ")*/
 
-	\delayUElev, (Pfunc({ |ev| ev.delayX.range(0.1, 90) })),
-	\selElev, (Pfunc({ |ev| case
-		{ev.delayUElev == 0.1} { 1 }
-		{ev.delayUElev == 90} { 2 }
-		{ev.delayUElev != 90} { 0 }
-	})),
-
-),
+			\delayUElev, (Pfunc({ |ev| ev.delayX.range(0.1, 90) })),
+			\selElev, (Pfunc({ |ev| case
+				{ev.delayUElev == 0.1} { 1 }
+				{ev.delayUElev == 90} { 2 }
+				{ev.delayUElev != 90} { 0 }
+			})),
+
+		),
 
-ambSD: Pbind(
+		ambSD: Pbind(
 
-	\outSpa, (Pkey(\prepfxL) * ~fxMulChannel)/*.trace(prefix: "outSpa -> ")*/,
+			\outSpa, (Pkey(\prepfxL) * ~fxMulChannel)/*.trace(prefix: "outSpa -> ")*/,
 
-	\pointScale, (Pfunc({ ~ambPointScale[track][~seqSeq[track]] })) /*.trace(prefix: "trajLevelScale -> ")*/,
-	\spaLagTime, Pfunc({ ~spaLagTime[track][~seqSeq[track]] }), // juste pour le lissage des spatialisations liées à l'analyse des paramètres spectraux ou d'intensité
-
-	\delayUElev, (Pfunc({ |ev| ev.delayX.range(-0.5pi, 0.5pi) })),
-	\selElev, (Pfunc({ |ev| case
-		{ev.delayUElev == (-0.5pi)} { 1 }
-		{ev.delayUElev == 0.5pi} { 2 }
-		{ev.delayUElev != 0.5pi} { 0 }
-	})),
+			\pointScale, (Pfunc({ ~ambPointScale[track][~seqSeq[track]] })) /*.trace(prefix: "trajLevelScale -> ")*/,
+			\spaLagTime, Pfunc({ ~spaLagTime[track][~seqSeq[track]] }), // juste pour le lissage des spatialisations liées à l'analyse des paramètres spectraux ou d'intensité
+
+			\delayUElev, (Pfunc({ |ev| ev.delayX.range(-0.5pi, 0.5pi) })),
+			\selElev, (Pfunc({ |ev| case
+				{ev.delayUElev == (-0.5pi)} { 1 }
+				{ev.delayUElev == 0.5pi} { 2 }
+				{ev.delayUElev != 0.5pi} { 0 }
+			})),
 
-	// ci-dessous pour le circulaire selon données spectrales
-	\freqMin, Pfunc({ ~sdFreqRangeMin[track][~seqSeq[track]] }),
-	\freqMax, Pfunc({ ~sdFreqRangeMax[track][~seqSeq[track]] }),
-	\freqCurve, Pfunc({ ~spaLagCurve[track][~seqSeq[track]] }),
-	\dbMin, Pfunc({ ~sdDbRangeMin[track][~seqSeq[track]] }),
-	\dbMax, Pfunc({ ~sdDbRangeMax[track][~seqSeq[track]] })
-
-	/*
-	// Pour effectuer les trajectoires Gauche / Droite
-	\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
-	\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
-	*/
-
-),
-
-ambTraj: Pbind(
-
-	\outSpa, (Pkey(\prepfxL) * ~fxMulChannel) /*.trace(prefix: "outSpa -> ")*/,
-
-	\pointScale, (Pfunc({ ~ambPointScale[track][~seqSeq[track]] })) /*.trace(prefix: "trajLevelScale -> ")*/,
-
-	\trajBufLoop, Pfunc({ ~trajSpatLoop[track][~seqSeq[track]] }) /*.trace(prefix: "trajBufLoop -> ")*/,
-
-	/*
-	\prepspa3, (Pfunc({ |ev| ev.prepspa.collect { |i| i - 18 } })) /*.trace(prefix: "prepspa3 -> ")*/,
-	\trajBuf, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][0] }, { ~trajectoryBuffers[i][0] }) } })) /*.trace(prefix: "trajBuf -> ")*/,
-	// Durée réelle de la trajectoire du buffer
-	\trajBufDur, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][1] }, { ~trajectoryBuffers[i][1] }) } })) /*.trace(prefix: "trajBufDur -> ")*/,
-	*/
-
-	\trajBufRatio, (Pfunc({ |ev| var seq = ~seqSeq[track];
-		case
-		{~trajSpatTimeType[track][seq] == 0} // Adapt Time
-		{ (ev.durenv / ev.trajBufDur).reciprocal }
-		{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ > ev.trajBufDur0/*[0]*/}} // Trajectory Time
-		{ (ev.durenv / ev.trajBufDur).reciprocal }
-		{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ <= ev.trajBufDur0/*[0]*/}} // Trajectory Time
-		{ 1 }
-		{~trajSpatTimeType[track][seq] == 2 } // Slider Time
-		{ /*ev.trajBufRat*/ ~trajSpatRate[track][seq] }
-	})) /*.trace(prefix: "trajBufRatio -> ")*/,
-
-	\delayUElev, (Pfunc({ |ev| ev.delayX.range(-0.5pi, 0.5pi) })),
-	\selElev, (Pfunc({ |ev| case
-		{ev.delayUElev == (-0.5pi)} { 1 }
-		{ev.delayUElev == 0.5pi} { 2 }
-		{ev.delayUElev != 0.5pi} { 0 }
-	}))
-
-),
-
-spec: Pbind(
-
-	\panSpectralCurve, (Pfunc({ ~spec2spaCurve[track][~seqSeq[track]] })) /*.trace(prefix: "panSpectralCurve -> ")*/
-
-	/*
-	// Pour effectuer les trajectoires Gauche / Droite - seulement utile pour les lines
-	\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
-	\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
-
-	// seulement utile pour les lines Aller ou Aller/retour
-	\spaSpeed, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.inclusivelyBetween(2,3), {0}, {1} ) } }) ),
-	*/
-
-),
-
-acous: Pbind(
-
-	// \outsL, (Pfunc({ |ev| [~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][0]] })) /*.trace(prefix: "Outs L -> ")*/,
-	// Le fait de ne pas mettre une Array autour provoque le déclenchement de 2 synthés au lieu d'1, l'un avec les arguments par défaut et l'autre avec les argument de \outsL
-
-	// Pour prendre en compte les FX
-	/*\outL, Pif((Pkey(\prepfxL) <= 0),
-	(Pkey(\prepoutL) - 1),
-	(Pkey(\prepoutL) - 1) + (Pkey(\prepfxL) * ~fxMulChannel)) /*.trace(prefix: "L -> ")*/,*/
-
-	\outsL, (Pfunc({ |ev|
-		if ( ev.prepfxL <= 0, {
-			[~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][0]]
-		},{
-			[~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][0] + (ev.prepfxL * ~fxMulChannel)]
-		});
-	})) /*.trace(prefix: "Outs L -> ")*/,
-
-	// \outsR, (Pfunc({ |ev| [~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][1]] })) /*.trace(prefix: "Outs R -> ")*/,
-	// ~bigStereoOuts[31-(18+~allSpasGUIAmbi.size)][1]
-
-	\outsR, (Pfunc({ |ev| if ( ev.prepfxR <= 0, {
-		[~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][1]]
-	},{
-		[~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][1] + (ev.prepfxR * ~fxMulChannel)]
-	});
-	})) /*.trace(prefix: "Outs R -> ")*/,
-
-),
-
-others: Pbind(
-
-	/*// ci-dessous pas forcément nécessaire / seulement utile pour visualisation si pas trop gourmand en CPU XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX - apparemment non
-	// à retirer du synthé et rajouter les arguments pour éviter doublon
-	\panCircMReg, (Pfunc({ |ev| /*ev.pan.lincurve(-1, 1, 20, 0.1, -4)*/ ev.pan.abs.linexp(0, 1, 0.01, ~circSpeedRangeMax[track][~seqSeq[track]]) })) /*.trace(prefix: "pannning CircM Reg -> ")*/,
-	/*
-	0.5.lincurve(0, 1, 0.1, 66, 6)
-	0.5.linexp(0, 1, 0.1, 66)
-	*/
-
-	// obligé de mettre 0.001 ci-dessous car panCircMVarMax utilise une fonction exponentielle et ne peut pas recevoir 0
-	// Place dans le coeur du Pbind car generetion dune erreur avec le retour visuel
-	\panCircMVarMin, (Pfunc({ |ev| (ev.prepoutRU * ~circSpeedRangeMin[track][~seqSeq[track]]) + 0.001 })) /*.trace(prefix: "pannning CircM Var min -> ")*/,
-	\panCircMVarMax, (Pfunc({ |ev| /*ev.panU.range(ev.prepoutRU*3, 20)*/ /*ev.pan.lincurve(-1, 1, 20, ev.panCircMVarMin, -4)*/ ev.pan.abs.linexp(0, 1, ev.panCircMVarMin, ~circSpeedRangeMax[track][~seqSeq[track]]) })) /*.trace(prefix: "pannning CircM Var max -> ")*/,*/
-
-)
-
-))
+			// ci-dessous pour le circulaire selon données spectrales
+			\freqMin, Pfunc({ ~sdFreqRangeMin[track][~seqSeq[track]] }),
+			\freqMax, Pfunc({ ~sdFreqRangeMax[track][~seqSeq[track]] }),
+			\freqCurve, Pfunc({ ~spaLagCurve[track][~seqSeq[track]] }),
+			\dbMin, Pfunc({ ~sdDbRangeMin[track][~seqSeq[track]] }),
+			\dbMax, Pfunc({ ~sdDbRangeMax[track][~seqSeq[track]] })
+
+			/*
+			// Pour effectuer les trajectoires Gauche / Droite
+			\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
+			\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
+			*/
+
+		),
+
+		ambTraj: Pbind(
+
+			\outSpa, (Pkey(\prepfxL) * ~fxMulChannel) /*.trace(prefix: "outSpa -> ")*/,
+
+			\pointScale, (Pfunc({ ~ambPointScale[track][~seqSeq[track]] })) /*.trace(prefix: "trajLevelScale -> ")*/,
+
+			\trajBufLoop, Pfunc({ ~trajSpatLoop[track][~seqSeq[track]] }) /*.trace(prefix: "trajBufLoop -> ")*/,
+
+			/*
+			\prepspa3, (Pfunc({ |ev| ev.prepspa.collect { |i| i - 18 } })) /*.trace(prefix: "prepspa3 -> ")*/,
+			\trajBuf, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][0] }, { ~trajectoryBuffers[i][0] }) } })) /*.trace(prefix: "trajBuf -> ")*/,
+			// Durée réelle de la trajectoire du buffer
+			\trajBufDur, (Pfunc({ |ev| ev.prepspa3.collect { |i| if (i < 0, { ~trajectoryBuffers[0][1] }, { ~trajectoryBuffers[i][1] }) } })) /*.trace(prefix: "trajBufDur -> ")*/,
+			*/
+
+			\trajBufRatio, (Pfunc({ |ev| var seq = ~seqSeq[track];
+				case
+				{~trajSpatTimeType[track][seq] == 0} // Adapt Time
+				{ (ev.durenv / ev.trajBufDur).reciprocal }
+				{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ > ev.trajBufDur0/*[0]*/}} // Trajectory Time
+				{ (ev.durenv / ev.trajBufDur).reciprocal }
+				{~trajSpatTimeType[track][seq] == 1 and: {ev.durenv0/*[0]*/ <= ev.trajBufDur0/*[0]*/}} // Trajectory Time
+				{ 1 }
+				{~trajSpatTimeType[track][seq] == 2 } // Slider Time
+				{ /*ev.trajBufRat*/ ~trajSpatRate[track][seq] }
+			})) /*.trace(prefix: "trajBufRatio -> ")*/,
+
+			\delayUElev, (Pfunc({ |ev| ev.delayX.range(-0.5pi, 0.5pi) })),
+			\selElev, (Pfunc({ |ev| case
+				{ev.delayUElev == (-0.5pi)} { 1 }
+				{ev.delayUElev == 0.5pi} { 2 }
+				{ev.delayUElev != 0.5pi} { 0 }
+			}))
+
+		),
+
+		spec: Pbind(
+
+			\panSpectralCurve, (Pfunc({ ~spec2spaCurve[track][~seqSeq[track]] })) /*.trace(prefix: "panSpectralCurve -> ")*/
+
+			/*
+			// Pour effectuer les trajectoires Gauche / Droite - seulement utile pour les lines
+			\panL, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.odd, {1}, {-1} ) } })) /*.trace(prefix: "panL -> ")*/,
+			\panR, (Pfunc({ |ev| ev.panL * (-1)	})) /*.trace(prefix: "panR -> ")*/,
+
+			// seulement utile pour les lines Aller ou Aller/retour
+			\spaSpeed, (Pfunc({ |ev| ev.prepspa.collect { |i| if (i.inclusivelyBetween(2,3), {0}, {1} ) } }) ),
+			*/
+
+		),
+
+		acous: Pbind(
+
+			// \outsL, (Pfunc({ |ev| [~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][0]] })) /*.trace(prefix: "Outs L -> ")*/,
+			// Le fait de ne pas mettre une Array autour provoque le déclenchement de 2 synthés au lieu d'1, l'un avec les arguments par défaut et l'autre avec les argument de \outsL
+
+			// Pour prendre en compte les FX
+			/*\outL, Pif((Pkey(\prepfxL) <= 0),
+			(Pkey(\prepoutL) - 1),
+			(Pkey(\prepoutL) - 1) + (Pkey(\prepfxL) * ~fxMulChannel)) /*.trace(prefix: "L -> ")*/,*/
+
+			\outsL, (Pfunc({ |ev|
+				if ( ev.prepfxL <= 0, {
+					[~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][0]]
+				},{
+					[~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][0] + (ev.prepfxL * ~fxMulChannel)]
+				});
+			})) /*.trace(prefix: "Outs L -> ")*/,
+
+			// \outsR, (Pfunc({ |ev| [~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][1]] })) /*.trace(prefix: "Outs R -> ")*/,
+			// ~bigStereoOuts[31-(18+~allSpasGUIAmbi.size)][1]
+
+			\outsR, (Pfunc({ |ev| if ( ev.prepfxR <= 0, {
+				[~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][1]]
+			},{
+				[~bigStereoOuts[ev.prepspa0-(18+~allSpasGUIAmbi.size)][1] + (ev.prepfxR * ~fxMulChannel)]
+			});
+			})) /*.trace(prefix: "Outs R -> ")*/,
+
+		),
+
+		others: Pbind(
+
+			/*// ci-dessous pas forcément nécessaire / seulement utile pour visualisation si pas trop gourmand en CPU XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX - apparemment non
+			// à retirer du synthé et rajouter les arguments pour éviter doublon
+			\panCircMReg, (Pfunc({ |ev| /*ev.pan.lincurve(-1, 1, 20, 0.1, -4)*/ ev.pan.abs.linexp(0, 1, 0.01, ~circSpeedRangeMax[track][~seqSeq[track]]) })) /*.trace(prefix: "pannning CircM Reg -> ")*/,
+			/*
+			0.5.lincurve(0, 1, 0.1, 66, 6)
+			0.5.linexp(0, 1, 0.1, 66)
+			*/
+
+			// obligé de mettre 0.001 ci-dessous car panCircMVarMax utilise une fonction exponentielle et ne peut pas recevoir 0
+			// Place dans le coeur du Pbind car generetion dune erreur avec le retour visuel
+			\panCircMVarMin, (Pfunc({ |ev| (ev.prepoutRU * ~circSpeedRangeMin[track][~seqSeq[track]]) + 0.001 })) /*.trace(prefix: "pannning CircM Var min -> ")*/,
+			\panCircMVarMax, (Pfunc({ |ev| /*ev.panU.range(ev.prepoutRU*3, 20)*/ /*ev.pan.lincurve(-1, 1, 20, ev.panCircMVarMin, -4)*/ ev.pan.abs.linexp(0, 1, ev.panCircMVarMin, ~circSpeedRangeMax[track][~seqSeq[track]]) })) /*.trace(prefix: "pannning CircM Var max -> ")*/,*/
+
+		)
+
+	))
 
 };
 
@@ -2100,7 +2126,7 @@ others: Pbind(
 			}})) /*.trace(prefix: "probU -> ")*/,
 			\preppro,	(Pfunc({ |ev| ~proSpec[track][~seqSeq[track]].map(ev.prepproU) * ~proMul[track][~seqSeq[track]]})) /*.trace(prefix: "prob -> ")*/,*/
 
-			\prepproU, (Prout({ var x, x2, r, seq; /*~proBlock[track] = 0;*/
+			\prepproU, (Prout({ var x, x2, r, seq, prev; /*~proBlock[track] = 0;*/
 				loop {
 					seq = ~seqSeq[track];
 					case
@@ -2342,16 +2368,21 @@ others: Pbind(
 						x2 = x2.linlin(x2.minItem, x2.maxItem, 0, 1);
 						~patternKeyRand2ElementCutLoopFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, ~proView, x2, 0);
 					}
-					/*// Pwrand([1,Pbjorklund2(5,16,1)/4],[0.8,0.2],inf)
-					// Pwrand([1, Pbjorklund(1, 2, 1, 0)],[0.9,0.1],inf).asStream.nextN(100) // XXXXXXXXXXXXXXXXXXXXX
+
+					/*// a = Pwrand([1,Pbjorklund2(5,16,1)/4],[0.8,0.2],inf).asStream; a.next // implémenté
+					// Pwrand([1, Pbjorklund(1, 2, 1, 0)],[0.6,0.1],inf).asStream.nextN(100) // XXXXXXXXXXXXXXXXXXXXX
+					Pwrand([1, Pbjorklund(1, 3, 1, 0)],[0.6,0.1],inf).asStream.nextN(100) // XXXXXXXXXXXXXXXXXXXXX
+					Pbjorklund(1, 2, 1, 0).asStream.nextN(100);
+					Pbjorklund(1, 3, 1, 0).asStream.nextN(100);
+					Pbjorklund(Pseq([1,2,3], inf), 4, inf).asStream.nextN(100)
 					{~proPatSel[track][seq] == 13 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}} // Pbjorklund
 					// Euclidean Algorithm for generating traditional musical rhythms
 					// args -> k (The number of hits), n (The total array size)
-					{x2 = Pwrand([1, Pbjorklund(~proBjor[track][seq], ~pro[track][seq].size, inf, ~proBjor2[track][seq]) ],[~test1,1-~test1],inf).asStream.nextN(~pro[track][seq].size);
+					{x2 = Pwrand([1, Pbjorklund(~proBjor[track][seq], ~pro[track][seq].size, inf, ~proBjor2[track][seq]) ],[~test,1-~test],inf).asStream.nextN(~pro[track][seq].size);
 					~patternKeyRand2ElementFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, ~proView, x2, 0);
 					}
 					{~proPatSel[track][seq] == 13 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}} // Pbjorklund (quand boucle cassée)
-					{x2 = Pwrand([1, Pbjorklund(~proBjor[track][seq], ~pro[track][seq].size, inf, ~proBjor2[track][seq]) ],[~test1,1-~test1],inf).asStream.nextN(~pro[track][seq].size);
+					{x2 = Pwrand([1, Pbjorklund(~proBjor[track][seq], ~pro[track][seq].size, inf, ~proBjor2[track][seq]) ],[~test,1-~test],inf).asStream.nextN(~pro[track][seq].size);
 					~patternKeyRand2ElementCutLoopFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, ~proView, x2, 0);
 					}*/
 					{~proPatSel[track][seq] == 13 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}} // Pbjorklund
@@ -2364,14 +2395,193 @@ others: Pbind(
 					{x2 = Pbjorklund(~proBjor[track][seq], ~pro[track][seq].size, inf, ~proBjor2[track][seq]).asStream.nextN(~pro[track][seq].size);
 						~patternKeyRand2ElementCutLoopFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, ~proView, x2, 0);
 					}
+					// Euclidean Algorithm with probability to alternate with 1 - the duration of the Euclidean sequence is determined by ~proBjor3
+					{~proPatSel[track][seq] == 14 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}} // EuWe
+					{x2 = Pwrand([1, Pbjorklund(~proBjor[track][seq], ~proBjor3[track][seq], 1, ~proBjor2[track][seq])], [~proWeight[track][seq], 1-~proWeight[track][seq]], inf).asStream;
+						~patternKeyRand0ElementFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+					{~proPatSel[track][seq] == 14 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}} // EuWe (quand boucle cassée)
+					{x2 = Pwrand([1, Pbjorklund(~proBjor[track][seq], ~proBjor3[track][seq], 1, ~proBjor2[track][seq])], [~proWeight[track][seq], 1-~proWeight[track][seq]], inf).asStream;
+						~patternKeyRand0ElementCutLoopFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+					// 2 Euclidean Algorithms with alternance Pxrand
+					{~proPatSel[track][seq] == 15 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}} // Eu2X
+					{x2 = Pxrand([Pbjorklund(~proBjor[track][seq], ~pro[track][seq].size, 1, ~proBjor2[track][seq]), Pbjorklund(~proBjor3[track][seq], ~pro[track][seq].size, 1, ~proBjor4[track][seq])], inf).asStream;
+						~patternKeyRand0ElementFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+					{~proPatSel[track][seq] == 15 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}} // Eu2X (quand boucle cassée)
+					{x2 = Pxrand([Pbjorklund(~proBjor[track][seq], ~pro[track][seq].size, 1, ~proBjor2[track][seq]), Pbjorklund(~proBjor3[track][seq], ~pro[track][seq].size, 1, ~proBjor4[track][seq])], inf).asStream;
+						~patternKeyRand0ElementCutLoopFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+					// 2 Euclidean Algorithms with random Pwhite
+					{~proPatSel[track][seq] == 16 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}} // Eu2R
+					{x2 = Pbjorklund(Pwhite(~proBjor[track][seq], ~proBjor3[track][seq]), ~pro[track][seq].size, inf, ~proBjor2[track][seq] /*Pwhite(~proBjor2[track][seq], ~proBjor4[track][seq])*/).asStream;
+						~patternKeyRand0ElementFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+					{~proPatSel[track][seq] == 16 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}} // Eu2R (quand boucle cassée)
+					{x2 = Pbjorklund(Pwhite(~proBjor[track][seq], ~proBjor3[track][seq]), ~pro[track][seq].size, inf, ~proBjor2[track][seq] /*Pwhite(~proBjor2[track][seq], ~proBjor4[track][seq])*/).asStream;
+						~patternKeyRand0ElementCutLoopFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+					// 2 Euclidean Algorithms in sequence with PShuf - Pseq does not work
+					/*
+					a = Pbjorklund(Pseq((~proBjor[~tracksValue][~seqsValue]..~proBjor3[~tracksValue][~seqsValue]), inf), ~pro[~tracksValue][~seqsValue].size, inf, Pseq((~proBjor[~tracksValue][~seqsValue]..~proBjor3[~tracksValue][~seqsValue]), inf) /*~proBjor2[~tracksValue][~seqsValue]*/ /*Pseq((~proBjor2[~tracksValue][~seqsValue]..~proBjor4[~tracksValue][~seqsValue]), inf)*/).asStream;
+					a.next;
+					*/
+					// Pourquoi le Pseq ou Pseries ne marche pas même sur le nb de Hits et pourquoi l'offset doit être fixe, sinon bug ?????????????????????
+					{~proPatSel[track][seq] == 17 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}} // Eu2S
+					{// x2 = Pbjorklund(/*Pseq*/ Pseries(~proBjor[track][seq], 1, ~proBjor3[track][seq]).asStream, ~pro[track][seq].size, inf, ~proBjor2[track][seq] /*Pseq((~proBjor2[track][seq]..~proBjor4[track][seq]), inf)*/).asStream;
+						x2 = Pbjorklund(/*Pseq*/ Pshuf((~proBjor[track][seq]..~proBjor3[track][seq]), inf), ~pro[track][seq].size, inf, ~proBjor2[track][seq] /*Pseq((~proBjor2[track][seq]..~proBjor4[track][seq]), inf)*/).asStream;
+						~patternKeyRand0ElementFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+					{~proPatSel[track][seq] == 17 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}} // Eu2S (quand boucle cassée)
+					{// x2 = Pbjorklund(/*Pseq*/ Pseries(~proBjor[track][seq], 1, ~proBjor3[track][seq]).asStream, ~pro[track][seq].size, inf, ~proBjor2[track][seq] /*Pseq((~proBjor2[track][seq]..~proBjor4[track][seq]), inf)*/).asStream;
+						x2 = Pbjorklund(/*Pseq*/ Pshuf((~proBjor[track][seq].copy..~proBjor3[track][seq]), inf), ~pro[track][seq].size, inf, ~proBjor2[track][seq] /*Pseq((~proBjor2[track][seq]..~proBjor4[track][seq]), inf)*/).asStream; // Pn Plazy
+						~patternKeyRand0ElementCutLoopFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+					// 2 Euclidean Algorithms with probability for the 1st one
+					{~proPatSel[track][seq] == 18 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}} // Eu2W
+					{x2 = Pwrand([Pbjorklund(~proBjor[track][seq], ~pro[track][seq].size, 1, ~proBjor2[track][seq]), Pbjorklund(~proBjor3[track][seq], ~pro[track][seq].size, 1, ~proBjor4[track][seq])], [~proWeight[track][seq], 1-~proWeight[track][seq]], inf).asStream;
+						~patternKeyRand0ElementFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+					{~proPatSel[track][seq] == 18 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}} // Eu2W (quand boucle cassée)
+					{x2 = Pwrand([Pbjorklund(~proBjor[track][seq], ~pro[track][seq].size, 1, ~proBjor2[track][seq]), Pbjorklund(~proBjor3[track][seq], ~pro[track][seq].size, 1, ~proBjor4[track][seq])], [~proWeight[track][seq], 1-~proWeight[track][seq]], inf).asStream;
+						~patternKeyRand0ElementCutLoopFunction.(currentEnvironment, track, seq, \pro, \posPro, \proBlock, x2);
+					}
+
+					// "Grids is a topographic drum sequencer and allows you to sequence up to six different sounds. Three in its basic mode, six with use of accent" ???
+					// Hacking Mutable Instruments Grids - Getting Started:
+					// https://www.youtube.com/watch?v=Eex-iLuUdiw
+					// https://goodtohear.co.uk/tools/grids-sequencer
+					// "Noise Engineering has Numeric Repetitor and Zularic Repetitor which operate similar to Grids."
+					// "Coupled with Doepfer quad switches and an Alesis DM-Pro is my percussive backbone."
+
+					// Mise en place de multiples sliders pour contrôler ScGrids et les variations Euclidiennes : ~proBjorGridsX, ~proBjorGridsY, ~gridsDens, ~proBjor3, ~proGridsBias, ~proBjor4, ~proWeight, ~proDrumType
+					// Still To Do : XXXXXXXXXXXXXXXXXX
+					// Faire un bouton random sur certains sliders du Grid comme GX et GY ou drumType
+					// Intégrer un LFO directement dans les paramètres du pattern comme X, Y ou chaos (voire ceux de Fredrik Oloffson) XXX
+					// Il serait bien d'ajouter le proWeight & proDrumType dans le Global
+					// Mettre à jour les valeurs dans les controleurs (notamment le Lemur)
+
+					// SC Grids modifié
+					// avec ornementation avec un % d'aléatoire sur des notes supplémentaires où le RangeView détermine le range du volume aléatoire
+					{~proPatSel[track][seq] == 19 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}}
+					{block{|break|
+						~pro[track][seq].size.do{|i| var gridsLevel;
+							if (~proBlock[track] == 1, {break.value}, {
+								~posPro[track][seq] = ((i % ~seqDurPro[track][seq]) + ~proSeqStart[track][seq])/*.postln*/; // necessary to get position ???
+								gridsLevel = ScGrids.calculateLevel(instrument: ~proDrumType[track][seq], curBeat: i, x: ~proBjorGridsX[track][seq], y: ~proBjorGridsY[track][seq], bias: ~proGridsBias[track][seq]);
+								if (gridsLevel >= (1-~gridsDens[track][seq]), {gridsLevel = gridsLevel}, { if (~proWeight[track][seq].coin, {gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq])}, {gridsLevel = 0}); /*gridsLevel = 0*/}); gridsLevel.yield;
+							})
+						}
+					}}
+					{~proPatSel[track][seq] == 19 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}}
+					{~proBlock[track] = 0; block{|break|
+						~seqGlobalRemainingSize[track].do{|i| var gridsLevel;
+							if (~proBlock[track] == 1, {break.value}, {
+								~posPro[track][seq] = ((~seqGlobalIndex[track] % ~seqDurPro[track][seq]) + ~proSeqStart[track][seq])/*.postln*/; // necessary to get position ???
+								gridsLevel = ScGrids.calculateLevel(instrument: ~proDrumType[track][seq], curBeat: i, x: ~proBjorGridsX[track][seq], y: ~proBjorGridsY[track][seq], bias: ~proGridsBias[track][seq]);
+								if (gridsLevel >= (1-~gridsDens[track][seq]), {gridsLevel = gridsLevel}, { if (~proWeight[track][seq].coin, {gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq])}, {gridsLevel = 0}); /*gridsLevel = 0*/}); gridsLevel.yield;
+							})
+						}
+					}}
+
+					// SC Grids prenant en compte la valeur précédente
+					// avec ornementation avec un % d'aléatoire sur des notes supplémentaires où le RangeView détermine le range du volume aléatoire
+					{~proPatSel[track][seq] == 20 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}}
+					{block{|break|
+						~pro[track][seq].size.do{|i| var gridsLevel;
+							if (~proBlock[track] == 1, {break.value}, {
+								~posPro[track][seq] = ((i % ~seqDurPro[track][seq]) + ~proSeqStart[track][seq])/*.postln*/; // necessary to get position ???
+								gridsLevel = ScGrids.calculateLevel(instrument: ~proDrumType[track][seq], curBeat: i, x: ~proBjorGridsX[track][seq], y: ~proBjorGridsY[track][seq], bias: ~proGridsBias[track][seq]);
+								// if (gridsLevel > (1-~gridsDens[track][seq]), {gridsLevel = 1- gridsLevel}, { if (~proWeight[track][seq].coin, {gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq])}, {gridsLevel = 0}); /*gridsLevel = 0*/}); gridsLevel.yield; // inverse de la valeur de gridsLevel, mais ne marche pas bien
+								if (gridsLevel >= (1-~gridsDens[track][seq]), {
+									gridsLevel = gridsLevel; prev = gridsLevel;
+								},{
+									if (~proWeight[track][seq].coin, {
+										gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq]); prev = 0;
+									},{
+										if (prev.notNil and: {prev > 0}, {gridsLevel = prev * ~proGridsBias2[track][seq]; prev = gridsLevel; /*gridsLevel.postln*/}, {gridsLevel = 0; prev = 0});
+									});
+								}); gridsLevel.yield; // "a".postln
+							})
+						}
+					}}
+					{~proPatSel[track][seq] == 20 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}}
+					{~proBlock[track] = 0; block{|break|
+						~seqGlobalRemainingSize[track].do{|i| var gridsLevel;
+							if (~proBlock[track] == 1, {break.value}, {
+								~posPro[track][seq] = ((~seqGlobalIndex[track] % ~seqDurPro[track][seq]) + ~proSeqStart[track][seq])/*.postln*/; // necessary to get position ???
+								gridsLevel = ScGrids.calculateLevel(instrument: ~proDrumType[track][seq], curBeat: i, x: ~proBjorGridsX[track][seq], y: ~proBjorGridsY[track][seq], bias: ~proGridsBias[track][seq]);
+								// if (gridsLevel > (1-~gridsDens[track][seq]), {gridsLevel = 1- gridsLevel}, { if (~proWeight[track][seq].coin, {gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq])}, {gridsLevel = 0}); /*gridsLevel = 0*/}); gridsLevel.yield; // inverse de la valeur de gridsLevel, mais ne marche pas bien
+								if (gridsLevel >= (1-~gridsDens[track][seq]), {
+									gridsLevel = gridsLevel; prev = gridsLevel;
+								},{
+									if (~proWeight[track][seq].coin, {
+										gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq]); prev = 0;
+									},{
+										if (prev.notNil and: {prev > 0}, {gridsLevel = prev * ~proGridsBias2[track][seq]; prev = gridsLevel; /*gridsLevel.postln*/}, {gridsLevel = 0; prev = 0});
+									});
+								}); gridsLevel.yield; // "b".postln
+							})
+						}
+					}}
+
+					// SC Grids aléatoire dans un range pour GX et GY (afin d'utiliser ~proGridsBias)
+					// avec ornementation avec un % d'aléatoire sur des notes supplémentaires où le RangeView détermine le range du volume aléatoire
+					{~proPatSel[track][seq] == 21 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}}
+					{block{|break|
+						~pro[track][seq].size.do{|i| var gridsLevel;
+							if (~proBlock[track] == 1, {break.value}, {
+								~posPro[track][seq] = ((i % ~seqDurPro[track][seq]) + ~proSeqStart[track][seq])/*.postln*/; // necessary to get position ???
+								gridsLevel = ScGrids.calculateLevel(instrument: ~proDrumType[track][seq], curBeat: i, x: (~proBjorGridsX[track][seq] + ~proGridsBias2[track][seq].rand2).clip(0,1), y: (~proBjorGridsY[track][seq] + ~proGridsBias2[track][seq].rand2).clip(0,1), bias: ~proGridsBias[track][seq]);
+								if (gridsLevel >= (1-~gridsDens[track][seq]), {gridsLevel = gridsLevel}, { if (~proWeight[track][seq].coin, {gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq])}, {gridsLevel = 0}); /*gridsLevel = 0*/}); gridsLevel.yield;
+							})
+						}
+					}}
+					{~proPatSel[track][seq] == 21 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}}
+					{~proBlock[track] = 0; block{|break|
+						~seqGlobalRemainingSize[track].do{|i| var gridsLevel;
+							if (~proBlock[track] == 1, {break.value}, {
+								~posPro[track][seq] = ((~seqGlobalIndex[track] % ~seqDurPro[track][seq]) + ~proSeqStart[track][seq])/*.postln*/; // necessary to get position ???
+								gridsLevel = ScGrids.calculateLevel(instrument: ~proDrumType[track][seq], curBeat: i, x: (~proBjorGridsX[track][seq] + ~proGridsBias2[track][seq].rand2).clip(0,1), y: (~proBjorGridsY[track][seq] + ~proGridsBias2[track][seq].rand2).clip(0,1), bias: ~proGridsBias[track][seq]);
+								if (gridsLevel >= (1-~gridsDens[track][seq]), {gridsLevel = gridsLevel}, { if (~proWeight[track][seq].coin, {gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq])}, {gridsLevel = 0}); /*gridsLevel = 0*/}); gridsLevel.yield;
+							})
+						}
+					}}
+
+					// SC Grids aléatoire entre 2 valeurs (pas d'utilisation de ~proGridsBias car pas assez de sliders pour random à la fois de GX et GY)
+					// avec ornementation avec un % d'aléatoire sur des notes supplémentaires où le RangeView détermine le range du volume aléatoire
+					{~proPatSel[track][seq] == 22 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 0}}
+					{block{|break|
+						~pro[track][seq].size.do{|i| var gridsLevel;
+							if (~proBlock[track] == 1, {break.value}, {
+								~posPro[track][seq] = ((i % ~seqDurPro[track][seq]) + ~proSeqStart[track][seq])/*.postln*/; // necessary to get position ???
+								gridsLevel = ScGrids.calculateLevel(instrument: ~proDrumType[track][seq], curBeat: i, x: ~proBjorGridsX[track][seq].rrand(~proGridsBias[track][seq]), y: ~proBjorGridsY[track][seq].rrand(~proGridsBias2[track][seq]));
+								if (gridsLevel >= (1-~gridsDens[track][seq]), {gridsLevel = gridsLevel}, { if (~proWeight[track][seq].coin, {gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq])}, {gridsLevel = 0}); /*gridsLevel = 0*/}); gridsLevel.yield;
+							})
+						}
+					}}
+					{~proPatSel[track][seq] == 22 and: { ~proPat[track][seq] == 1 } and: {~proBlock[track] == 1}}
+					{~proBlock[track] = 0; block{|break|
+						~seqGlobalRemainingSize[track].do{|i| var gridsLevel;
+							if (~proBlock[track] == 1, {break.value}, {
+								~posPro[track][seq] = ((~seqGlobalIndex[track] % ~seqDurPro[track][seq]) + ~proSeqStart[track][seq])/*.postln*/; // necessary to get position ???
+								gridsLevel = ScGrids.calculateLevel(instrument: ~proDrumType[track][seq], curBeat: i, x: ~proBjorGridsX[track][seq].rrand(~proGridsBias[track][seq]), y: ~proBjorGridsY[track][seq].rrand(~proGridsBias2[track][seq]));
+								if (gridsLevel >= (1-~gridsDens[track][seq]), {gridsLevel = gridsLevel}, { if (~proWeight[track][seq].coin, {gridsLevel = ~proMin[track][seq].rrand(~proMax[track][seq])}, {gridsLevel = 0}); /*gridsLevel = 0*/}); gridsLevel.yield;
+							})
+						}
+					}}
 
 			}})) /*.trace(prefix: "prepproU -> ")*/,
 
 			\preppro, (Pfunc({ |ev| var seq = ~seqSeq[track]; ~proSpec[track][seq].map(ev.prepproU * ~proMul[track][seq])})) /*.trace(prefix: "preppro -> ")*/,
 
-			\typePro, Pfunc({|ev| ev.preppro.coin })/*.trace(prefix: "typePro -> ")*/,
+			// \typePro, Pfunc({|ev| ev.preppro.coin })/*.trace(prefix: "typePro -> ")*/,
+			\typePro, Pfunc({|ev| var seq = ~seqSeq[track]; if (~proPatSel[track][seq] > 18 and: {~proPat[track][seq] == 1}, { if (/*~gridsLevel*/ ev.prepproU > 0, {true}, {false}) }, {ev.preppro.coin}) }) /*.trace(prefix: "typePro -> ")*/,
+
 			\typePro2, Pfunc({|ev| if (ev.typePro == true, {~proT[track] = ~proT[track]+1}, {~proT[track]} ); ~proT[track] }) /*.trace(prefix: "typePro2 -> ")*/, // Pour ne faire avancer les autres modules comme Buf ou Rat seulement quand une note est déclenchée // 0 redéclenché au début de chaque pattern
 			\typePro3, Pfunc({|ev| if (ev.typePro == true, {~proT2[track] = ~proT2[track]+1 }, {~proT2[track]} ); ~proT2[track] }) /*.trace(prefix: "typePro3 -> ")*/, // pour le Lehmer avec note
+			// voir à éliminer \typePro3 et remplacer ~proT2 par ~proT puisqu'il s'agit de toute façon de la même valeur ??? to check ???
 
 
 
@@ -2965,6 +3175,7 @@ others: Pbind(
 
 
 
+
 			\legU, (Prout({ ~patternKeyFunction.( currentEnvironment, track, \leg, \legDir, \legPat, \legPatSel, \posLeg, \seqDurLeg, \legSeqStart, \legSeqStop, \legBlock, ~legView) })) /*.trace(prefix: "legatoU -> ")*/,
 
 			\ampU, (Prout({ ~patternKeyFunction.( currentEnvironment, track, \amp, \ampDir, \ampPat, \ampPatSel, \posAmp, \seqDurAmp, \ampSeqStart, \ampSeqStop, \ampBlock, ~ampView) }))/*.trace(prefix: "ampU -> ")*/,
@@ -3022,6 +3233,7 @@ others: Pbind(
 
 			\amp, (Pfunc({ |ev| var seq = ~seqSeq[track];
 				case
+				{~proPatSel[track][seq] > 18 and: { ~proPat[track][seq] == 1 }} { ev.ampH * /*~gridsLevel*/ ev.prepproU } // Special case SC Grids
 				{~ampPatSel[track][seq] < ~controlBus0  or:  { ~ampPat[track][seq] == 0 }} { ev.ampH }
 				{~ampPatSel[track][seq] == ~controlBus0 and: { ~ampPat[track][seq] == 1 }} {~controlBus[ev.serverNb][0].asMap} // à normaliser de 0 à 1 ???
 				{~ampPatSel[track][seq] == ~controlBus1 and: { ~ampPat[track][seq] == 1 }} {~controlBus[ev.serverNb][1].asMap}
@@ -3091,35 +3303,37 @@ others: Pbind(
 				{ ~rtmPat[track][seq] == 0  or: {~rtmPatSel[track][seq] < 13}} { ev.durU }
 				{~rtmPatSel[track][seq] == 13 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.durU.max(maxV) }
 				{~rtmPatSel[track][seq] == 14 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.durU.max(maxV) }
-				{~rtmPatSel[track][seq] == 15 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.legU.max(maxV) }
-				{~rtmPatSel[track][seq] == 16 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.legU.max(maxV) }
-				{~rtmPatSel[track][seq] == 17 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.ampU.max(maxV) }
-				{~rtmPatSel[track][seq] == 18 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.ampU.max(maxV) }
-				{~rtmPatSel[track][seq] == 19 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.preprateU.max(maxV) }
-				{~rtmPatSel[track][seq] == 20 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.preprateU.max(maxV) }
-				{~rtmPatSel[track][seq] == 21 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.stretcherU.max(maxV) }
-				{~rtmPatSel[track][seq] == 22 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.stretcherU.max(maxV) }
-				{~rtmPatSel[track][seq] == 23 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.centerU.max(maxV) }
-				{~rtmPatSel[track][seq] == 24 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.centerU.max(maxV) }
-				{~rtmPatSel[track][seq] == 25 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.preprate2U.max(maxV) }
-				{~rtmPatSel[track][seq] == 26 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.preprate2U.max(maxV) }
-				{~rtmPatSel[track][seq] == 27 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.stretcher2U.max(maxV) }
-				{~rtmPatSel[track][seq] == 28 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.stretcher2U.max(maxV) }
-				{~rtmPatSel[track][seq] == 29 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.center2U.max(maxV) }
-				{~rtmPatSel[track][seq] == 30 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.center2U.max(maxV) }
-				{~rtmPatSel[track][seq] == 31 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.prepbufU.max(maxV) }
-				{~rtmPatSel[track][seq] == 32 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.prepbufU.max(maxV) }
-				{~rtmPatSel[track][seq] == 33 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.offsetU.max(maxV) }
-				{~rtmPatSel[track][seq] == 34 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.offsetU.max(maxV) }
-				{~rtmPatSel[track][seq] == 35 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.panU.max(maxV) }
-				{~rtmPatSel[track][seq] == 36 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.panU.max(maxV) }
-				{~rtmPatSel[track][seq] == 37 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.delayU.max(maxV) }
-				{~rtmPatSel[track][seq] == 38 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.delayU.max(maxV) }
-				{~rtmPatSel[track][seq] == 39 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.prepoutLU.max(maxV) }
-				{~rtmPatSel[track][seq] == 40 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.prepoutLU.max(maxV) }
-				{~rtmPatSel[track][seq] == 41 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.prepoutRU.max(maxV) }
-				{~rtmPatSel[track][seq] == 42 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.prepoutRU.max(maxV) }
-				{~rtmPatSel[track][seq] > 42 /*and: { ~rtmPat[track][seq] == 1 }*/} { ~posRtm[track][seq] = 100000; }
+				{~rtmPatSel[track][seq] == 15 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.prepproU.max(maxV) }
+				{~rtmPatSel[track][seq] == 16 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.prepproU.max(maxV) }
+				{~rtmPatSel[track][seq] == 17 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.legU.max(maxV) }
+				{~rtmPatSel[track][seq] == 18 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.legU.max(maxV) }
+				{~rtmPatSel[track][seq] == 19 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.ampU.max(maxV) }
+				{~rtmPatSel[track][seq] == 20 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.ampU.max(maxV) }
+				{~rtmPatSel[track][seq] == 21 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.preprateU.max(maxV) }
+				{~rtmPatSel[track][seq] == 22 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.preprateU.max(maxV) }
+				{~rtmPatSel[track][seq] == 23 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.stretcherU.max(maxV) }
+				{~rtmPatSel[track][seq] == 24 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.stretcherU.max(maxV) }
+				{~rtmPatSel[track][seq] == 25 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.centerU.max(maxV) }
+				{~rtmPatSel[track][seq] == 26 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.centerU.max(maxV) }
+				{~rtmPatSel[track][seq] == 27 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.preprate2U.max(maxV) }
+				{~rtmPatSel[track][seq] == 28 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.preprate2U.max(maxV) }
+				{~rtmPatSel[track][seq] == 29 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.stretcher2U.max(maxV) }
+				{~rtmPatSel[track][seq] == 30 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.stretcher2U.max(maxV) }
+				{~rtmPatSel[track][seq] == 31 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.center2U.max(maxV) }
+				{~rtmPatSel[track][seq] == 32 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.center2U.max(maxV) }
+				{~rtmPatSel[track][seq] == 33 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.prepbufU.max(maxV) }
+				{~rtmPatSel[track][seq] == 34 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.prepbufU.max(maxV) }
+				{~rtmPatSel[track][seq] == 35 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.offsetU.max(maxV) }
+				{~rtmPatSel[track][seq] == 36 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.offsetU.max(maxV) }
+				{~rtmPatSel[track][seq] == 37 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.panU.max(maxV) }
+				{~rtmPatSel[track][seq] == 39 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.panU.max(maxV) }
+				{~rtmPatSel[track][seq] == 39 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.delayU.max(maxV) }
+				{~rtmPatSel[track][seq] == 40 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.delayU.max(maxV) }
+				{~rtmPatSel[track][seq] == 41 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.prepoutLU.max(maxV) }
+				{~rtmPatSel[track][seq] == 42 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.prepoutLU.max(maxV) }
+				{~rtmPatSel[track][seq] == 43 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; ev.prepoutRU.max(maxV) }
+				{~rtmPatSel[track][seq] == 44 and: { ~rtmPat[track][seq] == 1 }} { ~posRtm[track][seq] = 1000; 1-ev.prepoutRU.max(maxV) }
+				{~rtmPatSel[track][seq] > 44 /*and: { ~rtmPat[track][seq] == 1 }*/} { ~posRtm[track][seq] = 100000; }
 			})) /*.trace(prefix: "durX -> ")*/,
 
 			/*\durX, (Pfunc({ |ev| var seq = ~seqSeq[track]; // Version sans mini comme ci-dessus
@@ -5685,67 +5899,67 @@ fork {
 		Pdef(~patterns[tr]).quant_(/*~quant[tr]*/ 0); Pdef(~patterns[tr]).pause;
 		~oneEvent[tr] = Pdef(~patterns[tr]).asStream;
 	};
-// };
+	// };
 
 
 
-~trackAllVolView.value_(~dbSpec.unmap(~globalVolume)).doAction; // pas forcément pris en compte avec .valueAction si on est déjà sur la même valeur
-// ~trackAllVolView.valueAction_(0); // ~globalVolume
+	~trackAllVolView.value_(~dbSpec.unmap(~globalVolume)).doAction; // pas forcément pris en compte avec .valueAction si on est déjà sur la même valeur
+	// ~trackAllVolView.valueAction_(0); // ~globalVolume
 
 
 
-/*
-Pdef(~patterns[0]).gui
-Pdef(~patterns[0]).asStream.iter
+	/*
+	Pdef(~patterns[0]).gui
+	Pdef(~patterns[0]).asStream.iter
 
-a = Pdef(~patterns[0]).asStream
-a.nextN(10)
+	a = Pdef(~patterns[0]).asStream
+	a.nextN(10)
 
-Pdef(~patterns[0]).asStream.asESP
-Editor.for(Event.default)
-Editor.for(~lastTrigEvent[0][0])
-*/
-
-
-
-/*~oneEvent = 0 ! ~nbOfSeqs ! ~nbOfTracks;
-
-{
-0.01.wait;
-~tracks.do { |tr|
-~nbOfSeqs.do { |seq|
-if (~presetSelection[tr][~presetSeqStart[tr]] != 0, {
-// try { ~presetGetFunctionQuick.value(~presetSelection[tr][~presetSeqStart[tr] /*~seqsValue*/].asSymbol, tr, ~presetSeqStart[tr]); };
-~tracksView.valueAction_(tr);
-~seqsView.valueAction_(seq);
-// try { ~presetGetFunction.value(~presetSelection[tr][~presetSeqStart[tr] /*~seqsValue*/].asSymbol/*, tr, ~presetSeqStart[tr];*/ ) };
-
-~play.value(npdef: ~patterns2[tr], track: (~tracks[tr]), nfade: ~nFade[tr], pfade: 0, quant: 0, stretchdur: 1/1);
-Pdef(~patterns2[tr]).quant_(/*~quant[tr]*/ 0); Pdef(~patterns2[tr]).pause;
-~oneEvent[tr][seq] = Pdef(~patterns2[tr]).asStream;
-})
-}
-};
-"fini".postln;
-}.fork(AppClock);*/
+	Pdef(~patterns[0]).asStream.asESP
+	Editor.for(Event.default)
+	Editor.for(~lastTrigEvent[0][0])
+	*/
 
 
 
+	/*~oneEvent = 0 ! ~nbOfSeqs ! ~nbOfTracks;
 
+	{
+	0.01.wait;
+	~tracks.do { |tr|
+	~nbOfSeqs.do { |seq|
+	if (~presetSelection[tr][~presetSeqStart[tr]] != 0, {
+	// try { ~presetGetFunctionQuick.value(~presetSelection[tr][~presetSeqStart[tr] /*~seqsValue*/].asSymbol, tr, ~presetSeqStart[tr]); };
+	~tracksView.valueAction_(tr);
+	~seqsView.valueAction_(seq);
+	// try { ~presetGetFunction.value(~presetSelection[tr][~presetSeqStart[tr] /*~seqsValue*/].asSymbol/*, tr, ~presetSeqStart[tr];*/ ) };
 
-/*
-~oneEvent[0].next(()).play; // 1ère piste
-~oneEvent[(~tracksValue/2).floor].next(()).play; // piste du ~tracksValue
-*/
-
-// Quelle est la vitesse de déclenchement lorsqu'on reste appuyé sur l'évaluation ?????????
+	~play.value(npdef: ~patterns2[tr], track: (~tracks[tr]), nfade: ~nFade[tr], pfade: 0, quant: 0, stretchdur: 1/1);
+	Pdef(~patterns2[tr]).quant_(/*~quant[tr]*/ 0); Pdef(~patterns2[tr]).pause;
+	~oneEvent[tr][seq] = Pdef(~patterns2[tr]).asStream;
+	})
+	}
+	};
+	"fini".postln;
+	}.fork(AppClock);*/
 
 
 
 
 
-// "Pattern Function & Routine triggered"; // n'est pas affichée la 1ère fois que fichier lancé ?????????
-0.2.wait; "Pattern Function & Routine triggered".postln;
+	/*
+	~oneEvent[0].next(()).play; // 1ère piste
+	~oneEvent[(~tracksValue/2).floor].next(()).play; // piste du ~tracksValue
+	*/
+
+	// Quelle est la vitesse de déclenchement lorsqu'on reste appuyé sur l'évaluation ?????????
+
+
+
+
+
+	// "Pattern Function & Routine triggered"; // n'est pas affichée la 1ère fois que fichier lancé ?????????
+	0.2.wait; "Pattern Function & Routine triggered".postln;
 
 	( // Uniquement Si le pattern (CmdPeriod) est arrêté, obligé de relancer l'APC Mini et le Morph - Pourquoi ?
 		if (~initAkai == 1, {"_Init Midi Ak.scd".loadRelative}); // Akai APC Mini à partir du Quark hacké d'Andrés Pérez López // ~akController = MKtl('pcmn0', "APC MINI");


### PR DESCRIPTION
Addition of multiple sliders to control Sc Grids and Euclidean variations :
- ~proBjorGridsX, ~proBjorGridsY, ~gridsDens, ~proBjor3, ~proGridsBias, ~proBjor4, ~proWeight, ~proDrumType

Addition of multiple algorithm variations (Euclidean & SC Grids) in the popup menu of the module PRO :
- [14. EuWe - args: proWeight, proBjor3]
-> Euclidean Algorithm with the probability to alternate with 1 depending on proWeight - ~proBjor3 determines the duration of the Euclidean sequence.
- [15. Eu2X - args: proBjor3, proBjor4]
-> Eculid double avec alternance Pxrand
- [16. Eu2R - args: proBjor3, proBjor4]
-> Eculid double avec Pwhite (entre les 2 valeurs comprises)
- [17. Eu2S - args: proBjor3, proBjor4]
-> Eculid double avec Pseq (entre les 2 valeurs comprises)
- [18. Eu2W - args: proWeight, proBjor3, proBjor4]
-> Eculid double avec Weight sur le 1er Pwrand
- [19. Grids - args: proWeight, proBjor3]
-> SC Grids with the probability to add notes (instead of silences) where the RangeView determines the range of the volume.
- [20. Gri_D - args: proWeight, proBjor3, proBjor4]
-> SC Grids taking into account the previous value and decreasing according to proBjor4 and the same probility as 19
- [21. Gri_P - args: proWeight, proBjor3, proBjor4]
-> SC Grids randomized by a % determined by proBjor3 and the same probility as 19 (use of proBias)
- [22. Gri_R - args: proWeight, proBjor3, proBjor4]
-> SC Grids randomized between 2 X and 2 Y and the same probility as 19 (no proBias since an additional slider would be necessary)
- More SC Grids variations or hacked variations ... see https://goodtohear.co.uk/tools/grids-sequencer

Also now possible to assign prepproU to other parameters like buffers and playback speeds