### PR TITLE
Modify Preset call in GUI file because of bad preset storings for some sequences

### DIFF
--- a/L4L_Project/_0A_Init_Live4Life.scd
+++ b/L4L_Project/_0A_Init_Live4Life.scd
@@ -19,7 +19,7 @@
 
 
 // Lemur OSC Connection - if you have the Lemur App, set the Lemur IP provided in the settings of the Lemur App - you can use up to 2 tactile tablets
-~lemurConnected1 = 1; ~lemurAdress1 = NetAddr( "192.168.2.2", 8000);
+~lemurConnected1 = 1; ~lemurAdress1 = NetAddr( "192.168.2.3", 8000);
 ~lemurConnected2 = 1; ~lemurAdress2 = NetAddr( "192.168.1.11", 8000);
 ~lemurConnected1 = 0; ~lemurAdress1 = nil; ~lemurConnected2 = 0; ~lemurAdress2 = nil;
 

--- a/L4L_Project/_2_Init_GUI_225.scd
+++ b/L4L_Project/_2_Init_GUI_225.scd
@@ -17135,7 +17135,8 @@ voire si la suppression des spec permet de réduire de manière conséquente le 
 	~buf[~tracksValue][~seqsValue] = Array.newClear(rtmSeqSize); ~bufView.valueAction_(~presets[index][\bufView]);
 	~off[~tracksValue][~seqsValue] = Array.newClear(rtmSeqSize); ~offView.valueAction_(~presets[index][\offView]);
 
-	if (~presets[index][\off2View].notNil, {
+	if (~presets[index][\off2View].notNil and: {~presets[index][\off2View].size == rtmSeqSize}, {
+		// obligé de rajouter "and: {~presets[index][\off2View].size == rtmSeqSize}", car pour certains presets, la taille des arrays est différente entre ~off2, ~off3 & rtmSeqSize - necessqire qu'aux presets de Paramegiani - pourrait être supprimé
 		~off2[~tracksValue][~seqsValue] = Array.newClear(rtmSeqSize); ~off2View.valueAction_(~presets[index][\off2View]);
 		~off3[~tracksValue][~seqsValue] = Array.newClear(rtmSeqSize); ~off3View.valueAction_(~presets[index][\off3View]);
 		~off4[~tracksValue][~seqsValue] = Array.newClear(rtmSeqSize); ~off4View.valueAction_(~presets[index][\off4View]);


### PR DESCRIPTION
Modify Preset call in GUI file because of bad preset storings for some sequences in size of off2 :
obligé de rajouter "and: {~presets[index][\off2View].size == rtmSeqSize}", car pour certains presets, la taille des arrays est différente entre ~off2, ~off3 & rtmSeqSize - necessqire qu'aux presets de Paramegiani - pourrait être supprimé